### PR TITLE
Fix: Added learn_from_experience method to ChimeraAgent

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -156,6 +156,26 @@ class ChimeraAgent:
     def record_experience(self, internal_state, action, reward):
         self.episode_memory.append({"state": internal_state, "action": action, "reward": reward})
 
+    def learn_from_experience(self, embedding):
+        """
+        Learns from a single sensory embedding in an unsupervised manner.
+        This updates the Hopfield and STAG/GNG components.
+        """
+        if not isinstance(embedding, np.ndarray):
+            embedding = np.array(embedding)
+
+        # 1. Update the Hopfield Core attractor landscape
+        self.hopfield.learn(embedding)
+
+        # 2. Update the topological map (STAG/GNG)
+        self.stag.process_input(embedding)
+
+        # Note: Saving the state after every single experience might be too slow
+        # for a real-world scenario, but for this API it ensures persistence.
+        self.save_state()
+
+        return {"status": "Unsupervised learning complete."}
+
     def train(self):
         if not self.episode_memory: return {"status": "No experiences to train on."}
 


### PR DESCRIPTION
I found that the 'ChimeraAgent' class was missing the 'learn_from_experience' method, which was being called by the '/learn' API endpoint. This was causing an AttributeError when the endpoint was used.

I have now implemented the 'learn_from_experience' method in the 'ChimeraAgent' class. The new method performs unsupervised learning by updating the agent's Hopfield network and STAG/GNG components with the provided sensory embedding. This aligns with the apparent design of the 'learn' endpoint and resolves the error.