### PR TITLE
Refactor ColosseumConnector to use a simplified, WebSocket-only conne…

### DIFF
--- a/backend/colosseum_connector.py
+++ b/backend/colosseum_connector.py
@@ -1,56 +1,35 @@
 import asyncio
 import json
-import aiohttp
+import uuid
 import websockets
 import logging
-from functools import partial
 
 logger = logging.getLogger(__name__)
 
 class ColosseumConnector:
     """
     Manages communication with a Colosseum game server for a single session,
-    handling both HTTP for session management and WebSockets for real-time gameplay.
+    handling WebSocket connection and gameplay.
     """
     def __init__(self, environment_id, agent_tag, host="127.0.0.1", http_port=8000, ws_port=8000):
-        self.http_base_url = f"http://{host}:{http_port}/api"
+        # http_port is no longer used but kept for compatibility with existing configs
         self.ws_base_url = f"ws://{host}:{ws_port}/ws"
         self.environment_id = environment_id
         self.agent_tag = agent_tag
         self.session_id = None
         self.websocket = None
 
-    async def create_session(self):
-        """Creates a new game session via the HTTP API."""
-        url = f"{self.http_base_url}/sessions/create/"
-        payload = {
-            "environment_id": self.environment_id,
-            "agent_tag": self.agent_tag,
-            "agent_name": f"ChimeraAgent-{self.agent_tag}",
-            "agent_type": "ai"
-        }
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(url, json=payload) as response:
-                    response.raise_for_status()
-                    data = await response.json()
-                    if data.get("success"):
-                        self.session_id = data.get("session_id")
-                        logger.info(f"Successfully created session: {self.session_id}")
-                        return data
-                    else:
-                        logger.error(f"Failed to create session: {data}")
-                        return None
-        except aiohttp.ClientError as e:
-            logger.error(f"HTTP error creating session: {e}")
-            return None
+    async def connect(self):
+        """
+        Establishes a connection to the Colosseum server by generating a new
+        session ID, creating a WebSocket connection, and joining the session.
+        Returns True on success, False on failure.
+        """
+        # 1. Generate a session ID on the client-side
+        self.session_id = str(uuid.uuid4())
+        logger.info(f"Generated new session ID: {self.session_id}")
 
-    async def connect_websocket(self):
-        """Connects to the session's WebSocket endpoint."""
-        if not self.session_id:
-            logger.error("Cannot connect WebSocket without a session ID.")
-            return False
-
+        # 2. Connect to the WebSocket endpoint
         uri = f"{self.ws_base_url}/session/{self.session_id}/"
         try:
             # The `create_protocol` argument is deprecated. Instead, pass custom
@@ -60,56 +39,60 @@ class ColosseumConnector:
                 extra_headers={"Origin": "http://localhost:3000"}
             )
             logger.info(f"Successfully connected to WebSocket: {uri}")
-            return True
         except websockets.exceptions.InvalidURI:
             logger.error(f"Invalid WebSocket URI: {uri}")
             return False
         except websockets.exceptions.ConnectionClosed as e:
             logger.error(f"WebSocket connection closed unexpectedly: {e}")
             return False
-        except TypeError as e:
-            # Catching the specific TypeError to provide a more helpful message.
-            logger.error(f"A TypeError occurred during WebSocket connection. This might be due to an incompatibility in the `websockets` library version. Error: {e}", exc_info=True)
+        except Exception as e:
+            logger.error(f"An unexpected error occurred during WebSocket connection: {e}", exc_info=True)
             return False
 
-    async def join_session(self):
-        """Sends the agent.join message to formally join the session."""
-        if not self.websocket:
-            return None
+        # 3. Join the session by sending an 'agent.join' message
+        try:
+            join_message = {
+                "type": "agent.join",
+                "agent_tag": self.agent_tag,
+                "environment_id": self.environment_id,
+            }
+            await self.websocket.send(json.dumps(join_message))
+            response = await self.receive_message()
 
-        # The session is identified by the WebSocket URL, so session_id is not needed in the payload.
-        # Aligning with the frontend client implementation.
-        join_message = {
-            "type": "agent.join",
-            "agent_tag": self.agent_tag,
-            "agent_name": f"ChimeraAgent-{self.agent_tag}",
-            "agent_type": "ai",
-            "environment_id": self.environment_id,
-        }
-        await self.websocket.send(json.dumps(join_message))
-        response = await self.receive_message()
-        if response and response.get("type") == "agent.joined":
-            logger.info(f"Agent {self.agent_tag} successfully joined session {self.session_id}")
-            return response
-        else:
-            logger.error(f"Failed to join session, response: {response}")
-            return None
+            if response and response.get("type") == "agent.joined":
+                logger.info(f"Agent {self.agent_tag} successfully joined session {self.session_id}")
+                return True
+            else:
+                error_detail = response.get('message', 'No details provided')
+                logger.error(f"Failed to join session. Server response: {error_detail}")
+                await self.close()
+                return False
+        except Exception as e:
+            logger.error(f"An error occurred while trying to join the session: {e}", exc_info=True)
+            await self.close()
+            return False
 
     async def send_action(self, action):
         """Sends an agent action to the server."""
-        if not self.websocket:
+        if not self.websocket or self.websocket.closed:
+            logger.error("Cannot send action, WebSocket is not connected.")
             return
 
-        action_message = {
-            "type": "agent.action",
-            "action": int(action),
-            "agent_tag": self.agent_tag # The server identifies the agent by its tag within the session
-        }
-        await self.websocket.send(json.dumps(action_message))
+        try:
+            action_message = {
+                "type": "agent.action",
+                "action": int(action),
+                "agent_tag": self.agent_tag
+            }
+            await self.websocket.send(json.dumps(action_message))
+        except Exception as e:
+            logger.error(f"Failed to send action: {e}", exc_info=True)
+
 
     async def receive_message(self):
         """Receives and parses a single message from the WebSocket."""
-        if not self.websocket:
+        if not self.websocket or self.websocket.closed:
+            logger.warning("Cannot receive message, WebSocket is not connected.")
             return None
         try:
             message = await self.websocket.recv()
@@ -117,9 +100,13 @@ class ColosseumConnector:
         except websockets.exceptions.ConnectionClosed:
             logger.warning("Connection closed while waiting for message.")
             return None
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse JSON from message: {e}")
+            return None
 
     async def close(self):
         """Closes the WebSocket connection."""
-        if self.websocket:
+        if self.websocket and not self.websocket.closed:
             await self.websocket.close()
             logger.info("WebSocket connection closed.")
+        self.websocket = None

--- a/backend/storage/test-hub-agent_history/history.json
+++ b/backend/storage/test-hub-agent_history/history.json
@@ -22,5 +22,13 @@
     "info": {
       "message": "Initial state."
     }
+  },
+  {
+    "version": 3,
+    "type": "diff",
+    "timestamp": "2025-08-23T06:34:21.739523",
+    "info": {
+      "message": "Initial state."
+    }
   }
 ]


### PR DESCRIPTION
…ction.

Based on the server-side implementation, the connector no longer needs to make an initial HTTP request to create a session.

This commit refactors the `ColosseumConnector` to:
- Generate a session ID on the client-side using UUID.
- Connect directly to the WebSocket endpoint.
- Send an `agent.join` message to have the server create the session record on-the-fly.
- Consolidate the connection logic into a single `connect()` method, removing the old `create_session()`, `connect_websocket()`, and `join_session()` methods.
- Remove the unused `aiohttp` dependency.