### PR TITLE
Refactor ColosseumConnector and update usage

### DIFF
--- a/backend/colosseum_connector.py
+++ b/backend/colosseum_connector.py
@@ -41,13 +41,13 @@ class ColosseumConnector:
             logger.info(f"Successfully connected to WebSocket: {uri}")
         except websockets.exceptions.InvalidURI:
             logger.error(f"Invalid WebSocket URI: {uri}")
-            return False
+            return None
         except websockets.exceptions.ConnectionClosed as e:
             logger.error(f"WebSocket connection closed unexpectedly: {e}")
-            return False
+            return None
         except Exception as e:
             logger.error(f"An unexpected error occurred during WebSocket connection: {e}", exc_info=True)
-            return False
+            return None
 
         # 3. Join the session by sending an 'agent.join' message
         try:
@@ -61,16 +61,16 @@ class ColosseumConnector:
 
             if response and response.get("type") == "agent.joined":
                 logger.info(f"Agent {self.agent_tag} successfully joined session {self.session_id}")
-                return True
+                return response
             else:
-                error_detail = response.get('message', 'No details provided')
+                error_detail = response.get('message', 'No details provided') if response else "No response from server"
                 logger.error(f"Failed to join session. Server response: {error_detail}")
                 await self.close()
-                return False
+                return None
         except Exception as e:
             logger.error(f"An error occurred while trying to join the session: {e}", exc_info=True)
             await self.close()
-            return False
+            return None
 
     async def send_action(self, action):
         """Sends an agent action to the server."""

--- a/backend/multi_session_manager.py
+++ b/backend/multi_session_manager.py
@@ -28,17 +28,17 @@ class MultiSessionManager:
         # 1. Create a connector for this session
         connector = ColosseumConnector(env_id, agent_tag)
 
-        # 2. Create the Colosseum session
-        session_data = await connector.create_session()
-        if not session_data:
-            logger.error(f"[{agent_tag}] Could not create Colosseum session. Exiting.")
+        # 2. Connect to the Colosseum and join the session
+        join_response = await connector.connect()
+        if not join_response:
+            logger.error(f"[{agent_tag}] Could not connect to Colosseum. Exiting.")
             return
 
         # 3. Create a ChimeraAgent instance for this session
         # We need to get obs_dim and action_dim from the environment spec
         # This is a simplification; a real implementation would query this from the server
         # or have it in a config file.
-        obs_dim = len(session_data.get("observation", []))
+        obs_dim = len(join_response.get("observation", []))
         # This is a HACK: we need a way to know the action space size.
         action_dim = 4 if "Lunar" in env_id else 2 # Default for CartPole
 
@@ -51,19 +51,7 @@ class MultiSessionManager:
         )
         self.agents[agent_tag] = agent
 
-        # 4. Connect to the WebSocket
-        if not await connector.connect_websocket():
-            logger.error(f"[{agent_tag}] WebSocket connection failed. Exiting.")
-            return
-
-        # 5. Join the session over WebSocket
-        join_response = await connector.join_session()
-        if not join_response:
-            logger.error(f"[{agent_tag}] Failed to join session over WebSocket. Exiting.")
-            await connector.close()
-            return
-
-        # 6. Main real-time gameplay loop
+        # 4. Main real-time gameplay loop
         try:
             current_obs = np.array(join_response.get("observation"))
             done = False

--- a/backend/storage/test-hub-agent_history/history.json
+++ b/backend/storage/test-hub-agent_history/history.json
@@ -30,5 +30,13 @@
     "info": {
       "message": "Initial state."
     }
+  },
+  {
+    "version": 4,
+    "type": "diff",
+    "timestamp": "2025-08-23T06:42:08.481255",
+    "info": {
+      "message": "Initial state."
+    }
   }
 ]


### PR DESCRIPTION
This commit refactors the `ColosseumConnector` to use a simplified, WebSocket-only connection, and updates the calling code in `MultiSessionManager` to use the new API.

Changes include:
- The `ColosseumConnector` no longer uses HTTP to create a session. Instead, it generates a UUID client-side and connects directly to the WebSocket endpoint.
- The `create_session`, `connect_websocket`, and `join_session` methods have been consolidated into a single `connect` method which returns the server's `agent.joined` response.
- The `MultiSessionManager` has been updated to call the new `connect` method and correctly handle the response to get the initial observation.
- The initial `TypeError` from an incompatible `websockets` library version was also fixed by using `extra_headers` instead of `create_protocol`.