### PR TITLE
Fix WebSocket connector connection handling

### DIFF
--- a/backend/colosseum_connector.py
+++ b/backend/colosseum_connector.py
@@ -74,7 +74,7 @@ class ColosseumConnector:
 
     async def send_action(self, action):
         """Sends an agent action to the server."""
-        if not self.websocket or self.websocket.closed:
+        if not self.websocket:
             logger.error("Cannot send action, WebSocket is not connected.")
             return
 
@@ -85,13 +85,15 @@ class ColosseumConnector:
                 "agent_tag": self.agent_tag
             }
             await self.websocket.send(json.dumps(action_message))
+        except websockets.exceptions.ConnectionClosed:
+            logger.warning("Cannot send action, connection is closed.")
         except Exception as e:
             logger.error(f"Failed to send action: {e}", exc_info=True)
 
 
     async def receive_message(self):
         """Receives and parses a single message from the WebSocket."""
-        if not self.websocket or self.websocket.closed:
+        if not self.websocket:
             logger.warning("Cannot receive message, WebSocket is not connected.")
             return None
         try:
@@ -106,7 +108,12 @@ class ColosseumConnector:
 
     async def close(self):
         """Closes the WebSocket connection."""
-        if self.websocket and not self.websocket.closed:
-            await self.websocket.close()
-            logger.info("WebSocket connection closed.")
+        if self.websocket:
+            try:
+                await self.websocket.close()
+                logger.info("WebSocket connection closed.")
+            except websockets.exceptions.ConnectionClosed:
+                logger.info("WebSocket connection was already closed.")
+            except Exception as e:
+                logger.error(f"Error while closing WebSocket: {e}", exc_info=True)
         self.websocket = None

--- a/backend/storage/test-hub-agent_history/history.json
+++ b/backend/storage/test-hub-agent_history/history.json
@@ -46,5 +46,13 @@
     "info": {
       "message": "Initial state."
     }
+  },
+  {
+    "version": 6,
+    "type": "diff",
+    "timestamp": "2025-08-23T07:03:20.547093",
+    "info": {
+      "message": "Initial state."
+    }
   }
 ]


### PR DESCRIPTION
This commit resolves a series of issues related to the Colosseum WebSocket connector, providing a robust, simplified, and compatible implementation.

The following fixes are included:
1.  **Fix `TypeError` on connect:** The initial `TypeError` (`create_connection() got an unexpected keyword argument 'create_protocol'`) was resolved by replacing the deprecated `create_protocol` argument with a modern way to pass headers.
2.  **Refactor `ColosseumConnector`:** The connector was refactored to use a simplified, WebSocket-only connection flow. The HTTP-based session creation was removed. The connector now generates a UUID client-side and connects directly, which aligns with the server's logic. The `create_session`, `connect_websocket`, and `join_session` methods were consolidated into a single `connect()` method.
3.  **Update `MultiSessionManager`:** The calling code in `multi_session_manager.py` was updated to use the new `connect()` method, resolving an `AttributeError` caused by the refactoring.
4.  **Fix `AttributeError` on `websocket.closed`:** A persistent `AttributeError: 'ClientConnection' object has no attribute 'closed'` was fixed by removing the check for the `.closed` attribute and instead relying on robust exception handling for operations on a closed connection.