### PR TITLE
Fix AttributeError in train_agent script

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -80,18 +80,7 @@ class Command(BaseCommand):
             for episode in range(num_episodes):
                 # --- Create a new session for each episode ---
                 connector = ColosseumConnector(env_name, agent_id)
-                session_data = await connector.create_session()
-                if not session_data:
-                    logger.error(f"Episode {episode + 1}: Could not create Colosseum session. Skipping.")
-                    pbar.update(1)
-                    continue
-
-                if not await connector.connect_websocket():
-                    logger.error(f"Episode {episode + 1}: WebSocket connection failed. Skipping.")
-                    pbar.update(1)
-                    continue
-
-                join_response = await connector.join_session()
+                join_response = await connector.connect()
                 if not join_response:
                     logger.error(f"Episode {episode + 1}: Failed to join session. Skipping.")
                     await connector.close()

--- a/backend/storage/test-hub-agent_history/history.json
+++ b/backend/storage/test-hub-agent_history/history.json
@@ -78,5 +78,13 @@
     "info": {
       "message": "Initial state."
     }
+  },
+  {
+    "version": 10,
+    "type": "base",
+    "timestamp": "2025-08-23T07:40:54.997658",
+    "info": {
+      "message": "Initial state."
+    }
   }
 ]


### PR DESCRIPTION
This commit fixes an `AttributeError: 'ColosseumConnector' object has no attribute 'create_session'` that occurred when running the `train_agent` management command.

The error was caused by the script using an outdated API for the `ColosseumConnector` after it was refactored to use a simplified, WebSocket-only connection flow.

The fix updates `api/management/commands/train_agent.py` to use the new `connector.connect()` method, aligning it with the refactored connector and resolving the crash.