### PR TITLE
Feat: Add environment reset for single-session training

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -74,69 +74,80 @@ class Command(BaseCommand):
         )
         logger.info(f"Agent '{agent.agent_id}' created. Starting Colosseum training for {num_episodes} episodes in '{env_name}'...")
 
+        # --- Create a single session for the entire training run ---
+        connector = ColosseumConnector(env_name, agent_id)
+        session_data = await connector.create_session()
+        if not session_data:
+            logger.error("Could not create Colosseum session. Exiting.")
+            return
+
+        if not await connector.connect_websocket():
+            logger.error("WebSocket connection failed. Exiting.")
+            return
+
+        join_response = await connector.join_session()
+        if not join_response:
+            logger.error("Failed to join session. Exiting.")
+            await connector.close()
+            return
+
+        # --- Training Loop ---
         total_rewards = []
+        current_obs = np.array(join_response.get("observation"))
 
-        with tqdm(total=num_episodes, desc="Training on Colosseum") as pbar:
-            for episode in range(num_episodes):
-                # --- Create a new session for each episode ---
-                connector = ColosseumConnector(env_name, agent_id)
-                session_data = await connector.create_session()
-                if not session_data:
-                    logger.error(f"Episode {episode + 1}: Could not create Colosseum session. Skipping.")
+        try:
+            with tqdm(total=num_episodes, desc="Training on Colosseum") as pbar:
+                for episode in range(num_episodes):
+                    episode_reward = 0
+                    done = False
+
+                    # --- Gameplay Loop for one episode ---
+                    while not done:
+                        agent.perceive_and_update_state("vector_input", current_obs)
+                        action, log_prob, stag_context = agent.select_action()
+
+                        await connector.send_action(action)
+                        msg = await connector.receive_message()
+
+                        if not msg or msg.get("type") != "action.taken":
+                            logger.warning(f"Unexpected message or disconnection: {msg}")
+                            done = True  # End episode on error
+                            continue
+
+                        next_obs = np.array(msg.get("observation"))
+                        reward = msg.get("reward")
+                        done = msg.get("done")
+
+                        total_reward = reward  # Simplified reward
+                        agent.record_experience(agent.hidden_state, stag_context, current_obs, action, log_prob, total_reward, next_obs, done)
+
+                        current_obs = next_obs
+                        episode_reward += reward
+
+                    # --- Post-Episode ---
+                    train_stats = agent.train()
+                    agent.save_state(version_info=train_stats)
+                    total_rewards.append(episode_reward)
+
+                    avg_reward = np.mean(total_rewards[-100:])
+                    pbar.set_postfix({
+                        "Reward": f"{episode_reward:.2f}",
+                        "Avg Rwd": f"{avg_reward:.2f}",
+                        "Policy Loss": self._safe_format(train_stats.get('policy_loss'), '.4f')
+                    })
                     pbar.update(1)
-                    continue
 
-                if not await connector.connect_websocket():
-                    logger.error(f"Episode {episode + 1}: WebSocket connection failed. Skipping.")
-                    pbar.update(1)
-                    continue
-
-                join_response = await connector.join_session()
-                if not join_response:
-                    logger.error(f"Episode {episode + 1}: Failed to join session. Skipping.")
-                    await connector.close()
-                    pbar.update(1)
-                    continue
-
-                # --- Gameplay Loop ---
-                current_obs = np.array(join_response.get("observation"))
-                episode_reward = 0
-                done = False
-
-                while not done:
-                    agent.perceive_and_update_state("vector_input", current_obs)
-                    action, log_prob, stag_context = agent.select_action()
-
-                    await connector.send_action(action)
-                    msg = await connector.receive_message()
-
-                    if not msg or msg.get("type") != "action.taken":
-                        logger.warning(f"Unexpected message or disconnection: {msg}")
-                        break
-
-                    next_obs = np.array(msg.get("observation"))
-                    reward = msg.get("reward")
-                    done = msg.get("done")
-
-                    total_reward = reward  # Simplified reward
-                    agent.record_experience(agent.hidden_state, stag_context, current_obs, action, log_prob, total_reward, next_obs, done)
-
-                    current_obs = next_obs
-                    episode_reward += reward
-
-                # --- Post-Episode ---
-                await connector.close()
-                train_stats = agent.train()
-                agent.save_state(version_info=train_stats)
-                total_rewards.append(episode_reward)
-
-                avg_reward = np.mean(total_rewards[-100:])
-                pbar.set_postfix({
-                    "Reward": f"{episode_reward:.2f}",
-                    "Avg Rwd": f"{avg_reward:.2f}",
-                    "Policy Loss": self._safe_format(train_stats.get('policy_loss'), '.4f')
-                })
-                pbar.update(1)
-
-        logger.info("Training finished.")
-        logger.info(f"Final agent state saved to {agent.history_manager.storage_dir}")
+                    # --- Reset for next episode ---
+                    if episode < num_episodes - 1:
+                        await connector.send_message({"type": "agent.reset"})
+                        msg = await connector.receive_message()
+                        if msg and msg.get("type") == "environment.reset":
+                            current_obs = np.array(msg.get("observation"))
+                        else:
+                            logger.error("Failed to reset environment, stopping training.")
+                            break
+        finally:
+            # --- Final cleanup ---
+            await connector.close()
+            logger.info("Training finished.")
+            logger.info(f"Final agent state saved to {agent.history_manager.storage_dir}")

--- a/backend/chimera_project/consumers.py
+++ b/backend/chimera_project/consumers.py
@@ -1,0 +1,1929 @@
+import json
+from channels.generic.websocket import AsyncWebsocketConsumer
+from games.services import GameManager
+import numpy as np
+from urllib.parse import parse_qs
+from channels.db import database_sync_to_async
+from games.models import GameSession, Agent, Trade
+import logging
+import traceback
+from django.core.cache import cache
+import time
+import uuid  # Added uuid import for clean session ID generation
+import redis
+
+logger = logging.getLogger(__name__)
+
+from games.serializers import (
+    TradeDataSerializer, SessionDataSerializer, MarketDataSerializer,
+    ActionResultSerializer, ActiveTradesResponseSerializer, ErrorResponseSerializer
+)
+from asgiref.sync import sync_to_async
+
+from games.tasks import queue_session_cleanup, queue_trade_threshold_check
+import json
+import uuid
+
+import django_rq
+from django_rq import get_queue
+
+from django.utils import timezone
+
+
+class NumpyEncoder(json.JSONEncoder):
+    """Custom JSON encoder that handles numpy arrays and data types"""
+
+    def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        elif isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
+        elif isinstance(obj, np.bool_):
+            return bool(obj)
+        elif hasattr(obj, 'tolist'):
+            return obj.tolist()
+        return super().default(obj)
+
+
+def safe_json_dumps(data):
+    """Safely serialize data to JSON, handling numpy arrays"""
+    return json.dumps(data, cls=NumpyEncoder)
+
+
+from games.services import GameManager
+
+game_manager = GameManager()
+
+
+class AgentConsumer(AsyncWebsocketConsumer):
+    """WebSocket consumer for agents to connect and play games"""
+
+    async def connect(self):
+        self.session_id = self.scope["url_route"]["kwargs"].get("session_id", "new")
+        self.agent_tag = None
+        normalized_session_id = self.session_id.replace('-', '').replace('/', '_').replace(' ', '_')
+        self.room_group_name = f"session_{normalized_session_id}"
+        self.env = None
+        self.environment_id = None
+        self.step_count = 0
+
+        logger.info(f"AgentConsumer connecting: session_id={self.session_id}")
+        await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+        await self.accept()
+        logger.info(f"AgentConsumer connected successfully: session_id={self.session_id}")
+
+    async def disconnect(self, close_code):
+        """Handle WebSocket disconnect - simplified without database operations"""
+        try:
+            logger.info(f"WebSocket disconnecting: {self.agent_tag}, code: {close_code}")
+
+            # Leave room group
+            if hasattr(self, 'room_group_name') and self.room_group_name:
+                await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
+
+            if self.agent_tag and self.session_id and self.session_id != "new":
+                from games.tasks import queue_session_cleanup
+                queue_session_cleanup(self.session_id, "agent_disconnect")
+                logger.info(f"Queued cleanup for session {self.session_id}")
+
+        except Exception as e:
+            logger.error(f"Error in disconnect cleanup: {e}")
+
+    async def receive(self, text_data):
+        logger.debug(f"AgentConsumer received data: {text_data}")
+        try:
+            data = json.loads(text_data)
+            message_type = data.get("type")
+            logger.debug(f"Message type: {message_type}")
+
+            if message_type == "agent.join":
+                await self.handle_agent_join(data)
+            elif message_type == "agent.action":
+                await self.handle_agent_action(data)
+            else:
+                logger.warning(f"Unknown message type: {message_type}")
+                await self.send_error("Unknown message type", "UNKNOWN_MESSAGE_TYPE")
+
+        except json.JSONDecodeError as e:
+            logger.error(f"JSON decode error: {e}")
+            await self.send_error("Invalid JSON", "INVALID_JSON")
+        except Exception as e:
+            logger.error(f"Error in receive: {e}")
+            logger.error(f"Traceback: {traceback.format_exc()}")
+            await self.send_error(f"Error: {str(e)}", "GENERAL_ERROR")
+
+    async def handle_agent_join(self, data):
+        """Handle agent joining a session - now creates database record directly"""
+        self.agent_tag = data.get("agent_tag")
+        self.environment_id = data.get("environment_id")
+        session_id = data.get("session_id", "new")
+
+        if not self.agent_tag or not self.environment_id:
+            logger.error("Missing agent_tag or environment_id")
+            await self.send_error("Missing agent_tag or environment_id", "MISSING_PARAMETERS")
+            return
+
+        try:
+            if self.is_day_trader_environment(self.environment_id):
+                await self.send_error("DayTrader environments should use HTTP API", "INVALID_ENVIRONMENT")
+                return
+
+            if session_id == "new":
+                self.session_id = str(uuid.uuid4())
+
+                # Create database record directly using database_sync_to_async
+                db_session = await self._create_database_session()
+
+                if db_session:
+                    # Set up WebSocket room
+                    normalized_session_id = self.session_id.replace('-', '_')
+                    self.room_group_name = f"session_{normalized_session_id}"
+                    await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+
+                    # Initialize gymnasium environment for immediate gameplay
+                    await self._initialize_environment()
+
+                    # Register in cache for viewers
+                    observation, info = self.env.reset()
+                    await self._register_session_in_cache(self.environment_id, observation, info)
+
+                    # Send immediate response with database session info
+                    response = {
+                        "type": "agent.joined",
+                        "session_id": self.session_id,
+                        "database_session_id": str(db_session.id),
+                        "environment_id": self.environment_id,
+                        "agent_tag": self.agent_tag,
+                        "observation": observation,
+                        "timestamp": time.time(),
+                        "status": "active"
+                    }
+
+                    await self.send_personal_message(response)
+                    logger.info(
+                        f"Agent joined with database session: {self.agent_tag} -> {self.session_id} (DB: {db_session.id})")
+                else:
+                    await self.send_error("Failed to create database session", "DATABASE_ERROR")
+            else:
+                # Handle joining existing session
+                await self.send_error("Joining existing sessions not yet supported", "NOT_IMPLEMENTED")
+
+        except Exception as e:
+            logger.error(f"Error in handle_agent_join: {e}")
+            await self.send_error(f"Failed to join session: {str(e)}", "JOIN_ERROR")
+
+    @database_sync_to_async
+    def _create_database_session(self):
+        """Create database session record directly"""
+        try:
+            from django.db import transaction
+            from games.models import GameSession, SessionAgent, Environment
+            from games.services import SessionManager
+            from django.utils import timezone
+            import uuid
+
+            with transaction.atomic():
+                # Get or create environment
+                environment, created = Environment.objects.get_or_create(
+                    env_id=self.environment_id,
+                    defaults={
+                        'name': self.environment_id.replace('-', ' ').title(),
+                        'description': f'Gymnasium {self.environment_id} environment',
+                        'env_type': 'gymnasium',
+                        'config': {}
+                    }
+                )
+
+                db_session = GameSession.objects.create(
+                    id=self.session_id,
+                    environment=environment,
+                    status='running',
+                    created_at=timezone.now(),
+                    last_activity=timezone.now(),
+                    current_step=0,
+                    total_reward=0.0,
+                    is_done=False,
+                    config={}
+                )
+
+                SessionAgent.objects.create(
+                    session=db_session,
+                    agent_tag=self.agent_tag,
+                    agent_name=f"Player-{self.agent_tag[:8]}",
+                    agent_type='human',
+                    player_id=0,  # First player for single-player environments
+                    is_active=True,
+                    joined_at=timezone.now(),
+                    last_action_at=timezone.now()
+                )
+
+                SessionManager.mark_session_active(str(db_session.id), 'websocket_session_created')
+
+                logger.info(f"[v0] Database session created: {db_session.id} for WebSocket session {self.session_id}")
+                return db_session
+
+        except Exception as e:
+            logger.error(f"[v0] Error creating database session: {e}")
+            return None
+
+    async def handle_agent_action(self, action_data):
+        """Handle agent action and broadcast to viewers"""
+        try:
+            if not self.env:
+                logger.error(f"Environment not initialized for session {self.session_id}")
+                await self.send_error("Environment not initialized", "ENV_NOT_INITIALIZED")
+                return
+
+            action = action_data.get("action")
+            if action is None:
+                await self.send_error("Action is required", "MISSING_ACTION")
+                return
+
+            logger.info(f"Agent {self.agent_tag} taking action {action} in session {self.session_id}")
+
+            # Take action in environment
+            observation, reward, done, truncated, info = self.env.step(action)
+
+            # Convert numpy types to Python types for JSON serialization
+            if hasattr(observation, 'tolist'):
+                observation = observation.tolist()
+
+            reward = float(reward) if reward is not None else 0.0
+            done = bool(done) if done is not None else False
+            truncated = bool(truncated) if truncated is not None else False
+
+            # Update session state
+            self.current_observation = observation
+            self.total_reward += reward
+            self.steps += 1
+
+            unified_data = {
+                "type": "action.taken",
+                "session_id": self.session_id,
+                "agent_tag": self.agent_tag,
+                "action": action,
+                "observation": observation,
+                "reward": reward,
+                "done": done,
+                "truncated": truncated,
+                "info": info,
+                "total_reward": self.total_reward,
+                "steps": self.steps,
+                "timestamp": time.time()
+            }
+
+            await self.send(text_data=safe_json_dumps(unified_data))
+
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {
+                    "type": "session_update",
+                    "data": unified_data
+                }
+            )
+
+            # Update session state in cache
+            await self._update_session_cache(observation, reward, done, info)
+
+            if done:
+                logger.info(f"Episode completed for session {self.session_id}")
+                await self.broadcast_game_over(self.total_reward, self.steps, "episode_complete")
+
+        except Exception as e:
+            logger.error(f"Error in handle_agent_action: {e}")
+            logger.error(f"Traceback: {traceback.format_exc()}")
+            await self.send_error(f"Action failed: {str(e)}", "ACTION_FAILED")
+
+    async def broadcast_action_taken(self, action, observation, reward, info):
+        """Broadcast action taken to all viewers in the same session"""
+        try:
+            message = {
+                "type": "action.taken",
+                "session_id": self.session_id,
+                "agent_tag": self.agent_tag,
+                "action": action,
+                "observation": observation,
+                "reward": float(reward) if reward is not None else 0.0,
+                "info": info,
+                "timestamp": time.time()
+            }
+
+            await self.channel_layer.group_send(self.room_group_name, {
+                "type": "session_update",
+                "message": safe_json_dumps(message)
+            })
+
+            logger.info(f"Broadcasted action to room {self.room_group_name}")
+
+        except Exception as e:
+            logger.error(f"Error broadcasting action: {e}")
+
+    async def broadcast_game_over(self, final_reward, total_steps, termination_reason="episode_complete"):
+        """Broadcast game over to viewers with termination details"""
+        try:
+            message = {
+                "type": "game.over",
+                "session_id": self.session_id,
+                "agent_tag": self.agent_tag,
+                "final_reward": float(final_reward) if final_reward is not None else 0.0,
+                "total_steps": total_steps,
+                "termination_reason": termination_reason,
+                "timestamp": time.time()
+            }
+
+            await self.channel_layer.group_send(self.room_group_name, {
+                "type": "session_update",
+                "message": safe_json_dumps(message)
+            })
+
+            logger.info(f"Broadcasted game over to room {self.room_group_name}: {termination_reason}")
+
+        except Exception as e:
+            logger.error(f"Error broadcasting game over: {e}")
+
+    async def _schedule_enhanced_session_cleanup(self, termination_reason: str):
+        """Schedule enhanced cleanup after episode ends"""
+        try:
+            from games.tasks import queue_session_cleanup
+
+            # Queue cleanup with delay to allow final broadcasts
+            await database_sync_to_async(queue_session_cleanup)(
+                self.session_id,
+                f"consumer_{termination_reason}",
+                delay_seconds=3
+            )
+
+            logger.info(f"Queued background cleanup for session {self.session_id}: {termination_reason}")
+
+        except Exception as e:
+            logger.error(f"Error scheduling enhanced session cleanup: {e}")
+
+    async def _cleanup_daytrader_session(self, termination_reason: str):
+        """Clean up DayTrader session-specific resources - now uses background tasks"""
+        try:
+            from django.core.cache import cache
+            from django.utils import timezone
+
+            # Remove from active sessions immediately
+            active_sessions = cache.get("daytrader_active_sessions", set())
+            active_sessions.discard(str(self.session_id))
+            cache.set("daytrader_active_sessions", active_sessions, timeout=3600)
+
+            # Broadcast session cleanup immediately
+            await self.channel_layer.group_send("day_trader_data", {
+                "type": "session_cleanup",
+                "data": {
+                    "session_id": str(self.session_id),
+                    "reason": termination_reason,
+                    "timestamp": timezone.now().isoformat()
+                }
+            })
+
+            logger.info(f"Immediate DayTrader cleanup completed for session {self.session_id}")
+
+        except Exception as e:
+            logger.error(f"Error in immediate DayTrader cleanup: {e}")
+
+    async def _initialize_environment(self):
+        """Initialize gymnasium environment for non-DayTrader sessions"""
+        try:
+            import gymnasium as gym
+            self.env = gym.make(self.environment_id)
+            observation, info = self.env.reset()
+            logger.info(f"Direct gymnasium environment created: {self.environment_id}")
+        except Exception as e:
+            logger.error(f"Failed to initialize environment: {e}")
+            await self.send_error(f"Failed to initialize environment: {str(e)}", "ENVIRONMENT_INITIALIZATION_FAILED")
+
+    async def _register_session_in_cache(self, environment_id, observation, info):
+        """Register direct gymnasium session in cache for viewers to detect"""
+        try:
+            session_data = {
+                "session_id": self.session_id,
+                "environment_id": environment_id,
+                "agent_tag": self.agent_tag,
+                "status": "running",
+                "created_at": time.time(),
+                "last_update": time.time(),
+                "current_observation": observation,
+                "total_reward": 0,
+                "steps": 0,
+                "info": info
+            }
+
+            # Store session data with multiple cache keys for detection
+            cache.set(f"gym_session_{self.session_id}", session_data, timeout=3600)
+            cache.set(f"active_agents_{self.session_id}", [self.agent_tag], timeout=3600)
+
+            active_sessions = cache.get("active_gym_sessions", set())
+            active_sessions.add(self.session_id)
+            cache.set("active_gym_sessions", active_sessions, timeout=3600)
+
+            logger.info(f"Registered session {self.session_id} in cache")
+
+        except Exception as e:
+            logger.error(f"Error registering session in cache: {e}")
+
+    async def _unregister_session_from_cache(self):
+        """Remove session from cache when agent disconnects"""
+        try:
+            cache.delete(f"gym_session_{self.session_id}")
+            cache.delete(f"active_agents_{self.session_id}")
+
+            # Remove from active sessions registry
+            active_sessions = cache.get("active_gym_sessions", set())
+            active_sessions.discard(self.session_id)
+            cache.set("active_gym_sessions", active_sessions, timeout=3600)
+
+            logger.info(f"Unregistered session {self.session_id} from cache")
+
+        except Exception as e:
+            logger.error(f"Error unregistering session from cache: {e}")
+
+    async def _update_session_cache(self, observation, reward, step_count):
+        """Update session data in cache with latest state"""
+        try:
+            session_data = cache.get(f"gym_session_{self.session_id}")
+            if session_data:
+                session_data.update({
+                    "current_observation": observation.tolist() if hasattr(observation, 'tolist') else observation,
+                    "total_reward": session_data.get("total_reward", 0) + reward,
+                    "steps": step_count,
+                    "last_update": time.time()
+                })
+                cache.set(f"gym_session_{self.session_id}", session_data, timeout=3600)
+
+        except Exception as e:
+            logger.error(f"Error updating session cache: {e}")
+
+    def _format_action_for_environment(self, action):
+        """Format action based on environment requirements"""
+        try:
+            env_id = getattr(self, 'environment_id', '').lower()
+
+            # Handle Pendulum environment - needs array format for continuous actions
+            if 'pendulum' in env_id:
+                if isinstance(action, (int, float)):
+                    # Convert scalar to array and scale to [-2, 2] range
+                    # Action 0 = -2, Action 1 = 0, Action 2 = +2
+                    if action == 0:
+                        return np.array([-2.0])
+                    elif action == 1:
+                        return np.array([0.0])
+                    elif action == 2:
+                        return np.array([2.0])
+                    else:
+                        # Clamp to valid range
+                        scaled_action = np.clip(float(action), -2.0, 2.0)
+                        return np.array([scaled_action])
+                elif isinstance(action, (list, tuple)):
+                    return np.array([np.clip(float(action[0]), -2.0, 2.0)])
+                else:
+                    return np.array([0.0])  # Default to no torque
+
+            # Handle Atari environments - discrete actions with specific ranges
+            elif any(atari_env in env_id for atari_env in ['breakout', 'spaceinvaders', 'pong', 'ale/']):
+                # Get valid action space size
+                action_space_size = getattr(self.env.action_space, 'n', 6)
+
+                # Clamp action to valid range
+                if isinstance(action, (int, float)):
+                    return int(np.clip(int(action), 0, action_space_size - 1))
+                else:
+                    return 0  # Default to no-op
+
+            # Handle other discrete environments
+            elif hasattr(self.env.action_space, 'n'):
+                action_space_size = self.env.action_space.n
+                if isinstance(action, (int, float)):
+                    return int(np.clip(int(action), 0, action_space_size - 1))
+                else:
+                    return 0
+
+            # Handle continuous action spaces
+            elif hasattr(self.env.action_space, 'shape'):
+                if isinstance(action, (int, float)):
+                    # Convert scalar to array
+                    return np.array([float(action)])
+                elif isinstance(action, (list, tuple)):
+                    return np.array([float(x) for x in action])
+                else:
+                    return np.array([0.0])
+
+            # Default: return action as-is
+            else:
+                return action
+
+        except Exception as e:
+            logger.error(f"Error formatting action: {e}")
+            # Return safe default based on action type
+            if isinstance(action, (int, float)):
+                return int(action) if action == int(action) else 0
+            else:
+                return 0
+
+    async def day_trader_tick(self, event):
+        """Handle real-time tick data from Day Trader streamer"""
+        try:
+            market_data = MarketDataSerializer.serialize_market_data(event["data"])
+            await self.send(text_data=safe_json_dumps({
+                "type": "market.tick",
+                "data": market_data,
+                "timestamp": time.time()
+            }))
+
+            # Queue trade threshold check for this tick
+            queue_trade_threshold_check(event["data"])
+        except Exception as e:
+            logger.error(f"Error handling day trader tick: {e}")
+
+    async def day_trader_candle(self, event):
+        """Handle real-time candlestick data from Day Trader streamer"""
+
+    async def trade_closed_notification(self, event):
+        """Handle trade closure notification broadcast from stream_deriv_data.py"""
+        try:
+            await self.send(text_data=safe_json_dumps({
+                "type": "trade.closed",
+                "data": event["data"],
+                "timestamp": time.time()
+            }))
+            logger.info(
+                f"[v0] Broadcasted trade closure notification for trade {event['data'].get('trade_id', 'unknown')}")
+        except Exception as e:
+            logger.error(f"Error broadcasting trade closure notification: {e}", exc_info=True)
+
+    async def broadcast_session_started(self, session_data):
+        """Broadcast session started to viewers"""
+        try:
+            message = {
+                "type": "session.started",
+                "session": session_data,
+                "timestamp": time.time()
+            }
+
+            await self.channel_layer.group_send(self.room_group_name, {
+                "type": "session_update",
+                "message": message
+            })
+
+            logger.info(f"Broadcasted session started to room {self.room_group_name}")
+
+        except Exception as e:
+            logger.error(f"Error broadcasting session started: {e}")
+
+    async def broadcast_game_over(self, final_reward, total_steps, termination_reason="episode_complete"):
+        """Broadcast game over to viewers"""
+        try:
+            message = {
+                "type": "game.over",
+                "session_id": self.session_id,
+                "agent_tag": self.agent_tag,
+                "final_reward": float(final_reward) if final_reward is not None else 0.0,
+                "total_steps": total_steps,
+                "termination_reason": termination_reason,
+                "timestamp": time.time()
+            }
+
+            await self.channel_layer.group_send(self.room_group_name, {
+                "type": "session_update",
+                "message": message
+            })
+
+            logger.info(f"Broadcasted game over to room {self.room_group_name}")
+
+        except Exception as e:
+            logger.error(f"Error broadcasting game over: {e}")
+
+    async def broadcast_agent_left(self):
+        """Broadcast agent left to viewers"""
+        try:
+            message = {
+                "type": "agent.left",
+                "session_id": self.session_id,
+                "agent_tag": self.agent_tag,
+                "timestamp": time.time()
+            }
+
+            await self.channel_layer.group_send(self.room_group_name, {
+                "type": "session_update",
+                "message": message
+            })
+
+            logger.info(f"Broadcasted agent left to room {self.room_group_name}")
+
+        except Exception as e:
+            logger.error(f"Error broadcasting agent left: {e}")
+
+    async def session_update(self, event):
+        """Handle session updates from broadcasts"""
+        data = event.get("data", event.get("message", {}))
+        await self.send(text_data=safe_json_dumps(data))
+
+    async def notify_game_start(self, session):
+        """Notify that game has started"""
+        try:
+            logger.info("Notifying game start")
+            session_data = await database_sync_to_async(SessionDataSerializer.serialize_session)(session)
+            await self.channel_layer.group_send(
+                f"session_viewers_{self.session_id}",
+                {
+                    "type": "session_update",
+                    "payload": {
+                        "type": "game.started",
+                        "session": session_data,
+                        "timestamp": time.time()
+                    }
+                }
+            )
+        except Exception as e:
+            logger.error(f"Error notifying game start: {e}")
+
+    async def send_personal_message(self, payload):
+        """Send message directly to this agent"""
+        try:
+            logger.debug(f"Sending personal message: {payload}")
+            await self.send(text_data=safe_json_dumps(payload))
+        except Exception as e:
+            logger.error(f"Error sending personal message: {e}")
+
+    async def send_error(self, message, code="GENERAL_ERROR"):
+        """Send standardized error message to agent"""
+        logger.error(f"Sending error to agent: {message}")
+        error_response = ErrorResponseSerializer.serialize_error(message, code)
+        await self.send_personal_message({
+            "type": "error",
+            **error_response
+        })
+
+    def is_day_trader_environment(self, environment_id):
+        """Check if the environment is a DayTrader environment"""
+        return environment_id.lower() in ['daytrader', 'day-trader',
+                                          'day_trader'] or 'daytrader' in environment_id.lower()
+
+    async def _schedule_session_end_cleanup(self):
+        """Schedule cleanup after episode ends"""
+        try:
+            import asyncio
+
+            async def delayed_cleanup():
+                await asyncio.sleep(3)  # Allow time for final state broadcasts
+                try:
+                    # Check if session should be cleaned up
+                    remaining_agents = await database_sync_to_async(game_manager.get_agent_count)(self.session_id)
+                    if remaining_agents <= 1:  # Only this agent or no agents
+                        await database_sync_to_async(game_manager.force_end_session)(self.session_id, "episode_ended")
+                        logger.info(f"Session {self.session_id} cleaned up after episode end")
+                except Exception as e:
+                    logger.error(f"Error in delayed cleanup: {e}")
+
+            # Schedule the cleanup
+            asyncio.create_task(delayed_cleanup())
+
+        except Exception as e:
+            logger.error(f"Error scheduling session end cleanup: {e}")
+
+
+class SessionViewerConsumer(AsyncWebsocketConsumer):
+    """WebSocket consumer for UI viewers to watch game sessions"""
+
+    async def connect(self):
+        original_session_id = self.scope["url_route"]["kwargs"]["session_id"]
+        self.session_id = original_session_id
+        self.viewer_id = None
+        self.room_group_name = f"session_{self.session_id.replace('-', '_')}"
+
+        logger.info(
+            f"SessionViewer attempting to connect to session: {original_session_id} -> normalized: {self.session_id}")
+        logger.info(f"SessionViewer room name: {self.room_group_name}")
+
+        session_exists = await self.check_session_exists()
+        if not session_exists:
+            logger.error(f"Session not found, closing connection: {self.session_id}")
+            await self.close(code=4004, reason="Session not found")
+            return
+
+        await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+        await self.accept()
+
+        logger.info(f"SessionViewer connected successfully to room: {self.room_group_name}")
+
+        session_state = await self.get_session_state()
+        await self.send(text_data=safe_json_dumps({
+            "type": "session.state",
+            "state": session_state,
+            "timestamp": time.time()
+        }))
+
+    async def disconnect(self, close_code):
+        if hasattr(self, 'room_group_name'):
+            await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
+
+    async def receive(self, text_data):
+        try:
+            data = json.loads(text_data)
+            message_type = data.get("type")
+
+            if message_type == "viewer.join":
+                self.viewer_id = data.get("viewer_id", f"viewer_{self.channel_name[-8:]}")
+                await self.send(text_data=safe_json_dumps({
+                    "type": "viewer.joined",
+                    "viewer_id": self.viewer_id,
+                    "session_id": self.session_id,
+                    "timestamp": time.time()
+                }))
+
+        except json.JSONDecodeError:
+            pass  # Viewers don't need to send valid actions
+
+    async def check_session_exists(self):
+        """Check if session exists in database or as active direct gymnasium session"""
+        try:
+            logger.info(f"Checking session existence for: {self.session_id}")
+
+            session_ids_to_check = [
+                self.session_id,  # Normalized format (no hyphens)
+                f"gym_{self.session_id}",  # Add gym_ prefix
+            ]
+
+            # Check database sessions first
+            for sid in session_ids_to_check:
+                try:
+                    db_session_exists = await database_sync_to_async(game_manager.session_exists)(sid)
+                    if db_session_exists:
+                        logger.info(f"Found database session: {sid}")
+                        self.session_id = sid  # Update to the found session ID
+                        return True
+                except Exception as e:
+                    logger.debug(f"Database session check failed for {sid}: {e}")
+
+            # Check cache with multiple formats
+            for sid in session_ids_to_check:
+                # Check gymnasium session cache
+                gym_session_data = cache.get(f"gym_session_{sid}")
+                if gym_session_data:
+                    logger.info(f"Found gymnasium session in cache: {sid}")
+                    self.session_id = sid  # Update to the found session ID
+                    return True
+
+                # Check active agents cache
+                active_agents = cache.get(f"active_agents_{sid}", [])
+                if len(active_agents) > 0:
+                    logger.info(f"Found active agents for session: {sid} - agents: {active_agents}")
+                    self.session_id = sid  # Update to the found session ID
+                    return True
+
+            # Check active sessions registry
+            active_sessions = cache.get("active_gym_sessions", set())
+            for sid in session_ids_to_check:
+                if sid in active_sessions:
+                    logger.info(f"Found session in active registry: {sid}")
+                    self.session_id = sid  # Update to the found session ID
+                    return True
+
+            logger.warning(f"Session not found in any cache. Debugging cache contents:")
+
+            try:
+                import redis
+                from django.conf import settings
+                r = redis.Redis.from_url(settings.CACHES['default']['LOCATION'])
+                gym_keys = r.keys("gym_session_*")
+                active_keys = r.keys("active_agents_*")
+                logger.warning(f"Available gym_session keys: {[k.decode() for k in gym_keys]}")
+                logger.warning(f"Available active_agents keys: {[k.decode() for k in active_keys]}")
+                logger.warning(f"Active gym sessions: {active_sessions}")
+                logger.warning(f"Tried session IDs: {session_ids_to_check}")
+            except Exception as e:
+                logger.warning(f"Could not debug cache contents: {e}")
+
+            logger.warning(f"Session not found: {self.session_id}")
+            return False
+
+        except Exception as e:
+            logger.error(f"Error checking session existence: {e}")
+            return False
+
+    async def get_session_state(self):
+        """Get current session state for both database and direct gymnasium sessions"""
+        try:
+            # Try database session first
+            try:
+                session_state = await database_sync_to_async(game_manager.get_session_state)(self.session_id)
+                if session_state:
+                    logger.info(f"Retrieved database session state for: {self.session_id}")
+                    return session_state
+            except Exception as e:
+                logger.debug(f"No database session found: {e}")
+
+            # Try to get detailed gymnasium session data from cache
+            gym_session_data = cache.get(f"gym_session_{self.session_id}")
+            if gym_session_data:
+                logger.info(f"Retrieved gymnasium session data from cache: {self.session_id}")
+                return {
+                    "session_id": self.session_id,
+                    "environment_id": gym_session_data.get("environment_id", "unknown"),
+                    "environment": gym_session_data.get("environment", "Unknown Environment"),
+                    "status": gym_session_data.get("status", "running"),
+                    "agent_count": 1,
+                    "agents": [{"name": gym_session_data.get("agent_tag", "AI Agent"), "type": "ai"}],
+                    "current_observation": gym_session_data.get("current_observation"),
+                    "total_reward": gym_session_data.get("total_reward", 0),
+                    "steps": gym_session_data.get("steps", 0),
+                    "viewer_count": 1,
+                    "history": [],
+                    "type": "direct_gymnasium",
+                    "last_update": gym_session_data.get("last_update", time.time())
+                }
+
+            # Fallback to minimal session state
+            logger.warning(f"Using fallback session state for: {self.session_id}")
+            return {
+                "session_id": self.session_id,
+                "status": "running",
+                "environment_id": "unknown",
+                "environment": "Unknown Environment",
+                "agent_count": 1,
+                "agents": [{"name": "AI Agent", "type": "ai"}],
+                "current_observation": None,
+                "total_reward": 0,
+                "steps": 0,
+                "viewer_count": 1,
+                "history": [],
+                "type": "direct_gymnasium",
+                "message": "Direct gymnasium session - limited state information available"
+            }
+
+        except Exception as e:
+            logger.error(f"Error getting session state: {e}")
+            return {
+                "session_id": self.session_id,
+                "status": "error",
+                "message": f"Error retrieving session state: {str(e)}"
+            }
+
+    async def session_update(self, event):
+        """Handle session updates from agent broadcasts"""
+        message = event.get("message", event.get("payload", {}))
+        logger.debug(f"SessionViewer received update: {message}")
+        await self.send(text_data=safe_json_dumps(message))
+
+
+class DayTraderDataConsumer(AsyncWebsocketConsumer):
+    """WebSocket consumer for DayTrader real-time data and actions"""
+
+    async def connect(self):
+        logger.info(f"[v0] DayTraderDataConsumer connection attempt from origin: {self.scope.get('headers', {})}")
+        logger.info(f"[v0] Connection path: {self.scope.get('path', 'unknown')}")
+
+        self.daytrader_session_id = None
+        self.agent_tag = None
+        self.is_session_initialized = False
+
+        self.room_group_name = f"day_trader_data"
+
+        logger.info(f"[v0] DayTraderDataConsumer connecting to general data stream")
+
+        try:
+            await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+            await self.accept()
+            logger.info(f"[v0] DayTraderDataConsumer connected successfully")
+        except Exception as e:
+            logger.error(f"[v0] Failed to accept WebSocket connection: {e}")
+            raise
+
+    async def disconnect(self, close_code):
+        logger.info(f"[v0] DayTraderDataConsumer disconnecting with code: {close_code}")
+        await self.channel_layer.group_discard(self.room_group_name, self.channel_name)
+
+    async def receive(self, text_data):
+        try:
+            logger.info(f"[v0] Received WebSocket message: {text_data[:100]}...")
+            data = json.loads(text_data)
+            message_type = data.get('type')
+
+            if message_type == 'daytrader_action':
+                await self.handle_daytrader_action(data)
+            elif message_type == 'daytrader.join':
+                await self.handle_daytrader_join(data)
+            else:
+                logger.warning(f"[v0] Unknown message type: {message_type}")
+        except json.JSONDecodeError as e:
+            logger.error(f"[v0] JSON decode error: {e}")
+            await self.send(text_data=safe_json_dumps({
+                "type": "error",
+                "message": "Invalid JSON format"
+            }))
+        except Exception as e:
+            logger.error(f"[v0] Error in receive: {e}", exc_info=True)
+            await self.send(text_data=safe_json_dumps({
+                "type": "error",
+                "message": str(e)
+            }))
+
+    async def trade_closed_notification(self, event):
+        """Handle trade closure notification broadcast from stream_deriv_data.py"""
+        try:
+            await self.send(text_data=safe_json_dumps({
+                "type": "trade.closed",
+                "data": event["data"],
+                "timestamp": time.time()
+            }))
+            logger.info(
+                f"[v0] Broadcasted trade closure notification for trade {event['data'].get('trade_id', 'unknown')}")
+        except Exception as e:
+            logger.error(f"Error broadcasting trade closure notification: {e}", exc_info=True)
+
+    async def handle_daytrader_join(self, data):
+        """Handle daytrader session join requests"""
+        try:
+            self.agent_tag = data.get("agent_tag")
+            self.daytrader_session_id = data.get("session_id", "new")
+
+            if not self.agent_tag:
+                logger.error("Missing agent_tag for daytrader join")
+                await self.send(text_data=safe_json_dumps({
+                    "type": "error",
+                    "message": "Missing agent_tag",
+                    "code": "MISSING_AGENT_TAG"
+                }))
+                return
+
+            # Mark session as initialized
+            self.is_session_initialized = True
+
+            # Send success response
+            await self.send(text_data=safe_json_dumps({
+                "type": "daytrader.joined",
+                "session_id": self.daytrader_session_id,
+                "agent_tag": self.agent_tag,
+                "timestamp": time.time()
+            }))
+
+            logger.info(f"[v0] DayTrader session joined: {self.agent_tag} -> {self.daytrader_session_id}")
+
+        except Exception as e:
+            logger.error(f"[v0] Error in handle_daytrader_join: {e}", exc_info=True)
+            await self.send(text_data=safe_json_dumps({
+                "type": "error",
+                "message": f"Failed to join daytrader session: {str(e)}",
+                "code": "DAYTRADER_JOIN_FAILED"
+            }))
+
+    async def handle_daytrader_action(self, data):
+        """DEPRECATED: DayTrader actions should be sent via HTTP POST to /api/daytrader/action/"""
+        logger.warning("Received daytrader_action via WebSocket, which is deprecated. Please use the HTTP endpoint.")
+        await self.send(text_data=safe_json_dumps({
+            "type": "error",
+            "message": "This WebSocket action is deprecated. Please use the HTTP POST endpoint for actions."
+        }))
+
+    async def trade_closed_reward(self, event):
+        """Handle trade closed reward broadcast"""
+        try:
+            reward_data = event.get('data', event)
+            await self.send(text_data=safe_json_dumps({
+                "type": "trade_closed_reward",
+                "data": reward_data,
+                "timestamp": time.time()
+            }))
+            logger.info(f"[v0] Broadcasted trade closed reward: {reward_data.get('reward', 0)} points")
+        except Exception as e:
+            logger.error(f"Error broadcasting trade closed reward: {e}", exc_info=True)
+
+    async def action_taken(self, event):
+        """Broadcast action taken to all clients"""
+        await self.send(text_data=safe_json_dumps({
+            "type": "action.taken",
+            "data": event["data"],
+            "timestamp": time.time()
+        }))
+
+    async def trade_closed_reward(self, event):
+        """Handle trade closed reward broadcast"""
+        try:
+            reward_data = event.get('data', event)
+            await self.send(text_data=safe_json_dumps({
+                "type": "trade_closed_reward",
+                "data": reward_data,
+                "timestamp": time.time()
+            }))
+            logger.info(f"[v0] Broadcasted trade closed reward: {reward_data.get('reward', 0)} points")
+        except Exception as e:
+            logger.error(f"Error broadcasting trade closed reward: {e}", exc_info=True)
+
+    async def action_taken(self, event):
+        """Broadcast action taken to all clients"""
+        await self.send(text_data=safe_json_dumps({
+            "type": "action.taken",
+            "data": event["data"],
+            "timestamp": time.time()
+        }))
+
+    async def day_trader_tick(self, event):
+        """Handle real-time tick data from Day Trader streamer"""
+        market_data = MarketDataSerializer.serialize_market_data(event["data"])
+        await self.send(text_data=safe_json_dumps({
+            "type": "market.tick",
+            "data": market_data,
+            "timestamp": time.time()
+        }))
+
+        queue_trade_threshold_check(event["data"])
+
+    async def day_trader_candle(self, event):
+        """Handle real-time candlestick data from Day Trader streamer"""
+        market_data = MarketDataSerializer.serialize_market_data(event["data"])
+        await self.send(text_data=safe_json_dumps({
+            "type": "market.candle",
+            "data": market_data,
+            "timestamp": time.time()
+        }))
+
+        queue_trade_threshold_check(event["data"])
+
+    def _remove_trade_from_cache(self, trade):
+        """Remove trade from cache and active trades tracking"""
+        try:
+            # Remove from Redis cache if exists
+            cache_key = f"trade:{trade.id}"
+            cache.delete(cache_key)
+
+            # Remove from session-specific cache
+            session_cache_key = f"session_trades:{trade.session_id}"
+            cached_trades = cache.get(session_cache_key, [])
+            cached_trades = [t for t in cached_trades if t.get('id') != str(trade.id)]
+            cache.set(session_cache_key, cached_trades, timeout=3600)
+
+            logger.info(f"Removed trade {trade.id} from cache")
+
+        except Exception as e:
+            logger.error(f"Error removing trade {trade.id} from cache: {e}")
+
+    def _broadcast_trade_closed(self, trade, realized_pnl, close_reason):
+        """Broadcast trade closure to all connected clients using standardized format"""
+        try:
+            from channels.layers import get_channel_layer
+            from asgiref.sync import async_to_sync
+
+            channel_layer = get_channel_layer()
+
+            trade_data = TradeDataSerializer.serialize_trade(trade, trade.exit_price)
+            trade_data.update({
+                'realized_pnl': realized_pnl,
+                'close_reason': close_reason,
+                'closed_at': time.time()
+            })
+
+            async_to_sync(channel_layer.group_send)("day_trader_data", {
+                "type": "trade.closed",
+                "data": trade_data
+            })
+
+        except Exception as e:
+            logger.error(f"Error broadcasting trade closure: {e}")
+
+    def _broadcast_episode_termination(self, session_id, reason):
+        """Broadcast episode termination to all connected clients"""
+        try:
+            from channels.layers import get_channel_layer
+            from asgiref.sync import async_to_sync
+
+            channel_layer = get_channel_layer()
+
+            termination_data = {
+                'session_id': str(session_id),  # Convert UUID to string
+                'reason': reason,
+                'terminated_at': time.time()
+            }
+
+            async_to_sync(channel_layer.group_send)("day_trader_data", {
+                "type": "episode.terminated",
+                "data": termination_data
+            })
+
+        except Exception as e:
+            logger.error(f"Error broadcasting episode termination: {e}")
+
+    async def recalculate_and_check_trade_thresholds(self, market_data):
+        """Recalculate trade P&L and check for terminal conditions on every tick"""
+        try:
+            from games.config import get_daytrader_config
+            daytrader_config = get_daytrader_config()
+
+            current_price = market_data.get('price', market_data.get('close', 0))
+
+            if not current_price:
+                return
+
+            logger.info(f"Checking trade thresholds with current price: {current_price}")
+
+            # Get all active DayTrader trades
+            active_trades = Trade.objects.filter(
+                status='open',
+                session__environment__env_id__icontains='daytrader'
+            ).select_related('session')
+
+            trades_to_close = []
+
+            for trade in active_trades:
+                try:
+                    pnl_ticks = 0
+                    if trade.trade_type == 'buy':
+                        pnl_ticks = current_price - trade.entry_price
+                    else:  # sell
+                        pnl_ticks = trade.entry_price - current_price
+
+                    # Update current P&L in ticks
+                    trade.current_pnl = pnl_ticks
+                    trade.save(update_fields=['current_pnl'])
+
+                    close_reason = None
+
+                    if pnl_ticks >= daytrader_config.TICK_PROFIT_LIMIT:
+                        close_reason = f"profit_limit_{daytrader_config.TICK_PROFIT_LIMIT}_ticks"
+                        logger.info(
+                            f"Trade {trade.id} hit {daytrader_config.TICK_PROFIT_LIMIT}-tick profit limit: {pnl_ticks} ticks")
+
+                    elif pnl_ticks <= daytrader_config.TICK_LOSS_LIMIT:
+                        close_reason = f"loss_limit_{abs(daytrader_config.TICK_LOSS_LIMIT)}_ticks"
+                        logger.info(
+                            f"Trade {trade.id} hit {abs(daytrader_config.TICK_LOSS_LIMIT)}-tick loss limit: {pnl_ticks} ticks")
+
+                    if close_reason:
+                        trades_to_close.append({
+                            'trade': trade,
+                            'current_price': current_price,
+                            'close_reason': close_reason,
+                            'market_data': market_data
+                        })
+                        logger.info(
+                            f"Trade {trade.id} will be closed: {close_reason}, P&L: {trade.current_pnl:.2f} ({pnl_ticks} ticks)")
+
+                except Exception as e:
+                    logger.error(f"Error processing trade {trade.id}: {e}")
+                    continue
+
+            # Close trades that reached thresholds
+            for trade_info in trades_to_close:
+                try:
+                    trade = trade_info['trade']
+                    realized_pnl = trade.close_trade(
+                        exit_price=trade_info['current_price'],
+                        exit_candle_index=market_data.get('candle_index', 0),
+                        close_reason=trade_info['close_reason'],
+                        market_data=trade_info['market_data']
+                    )
+
+                    # Remove from cache
+                    self._remove_trade_from_cache(trade)
+
+                    # Broadcast trade closure using standardized format
+                    self._broadcast_trade_closed(trade, realized_pnl, trade_info['close_reason'])
+
+                    logger.info(
+                        f"Trade {trade.id} closed automatically: {trade_info['close_reason']}, Realized P&L: {realized_pnl}")
+
+                except Exception as e:
+                    logger.error(f"Error closing trade {trade_info['trade'].id}: {e}")
+                    continue
+
+            sessions_to_check = set(trade_info['trade'].session_id for trade_info in trades_to_close)
+            for session_id in sessions_to_check:
+                try:
+                    # Check if session should be terminated based on episode-level conditions
+                    should_terminate, termination_reason = await self._check_session_terminal_conditions(session_id)
+
+                    if should_terminate:
+                        logger.info(f"Terminating episode for session {session_id} due to: {termination_reason}")
+                        self._broadcast_episode_termination(session_id, termination_reason)
+                        from games.tasks import queue_session_cleanup
+                        queue_session_cleanup(session_id, reason=termination_reason)
+                    else:
+                        logger.info(f"Session {session_id} continues after trade closure - no terminal conditions met")
+
+                except Exception as e:
+                    logger.error(f"Error checking terminal conditions for session {session_id}: {e}")
+
+            logger.info(f"Trade threshold checking completed: {len(trades_to_close)} trades closed")
+
+        except Exception as e:
+            logger.error(f"Error in recalculate_and_check_trade_thresholds: {e}")
+
+    async def _check_session_terminal_conditions(self, session_id):
+        """Check if a session should be terminated based on episode-level conditions"""
+        try:
+            from games.models import GameSession, Trade
+            from games.config import get_daytrader_config
+            from django.db import models
+
+            daytrader_config = get_daytrader_config()
+
+            session = await GameSession.objects.aget(id=session_id)
+
+            # Check if there are any remaining open trades
+            remaining_trades = await Trade.objects.filter(
+                session_id=session_id,
+                status='open'
+            ).acount()
+
+            # Calculate total session P&L
+            total_pnl_result = await Trade.objects.filter(
+                session_id=session_id,
+                status='closed'
+            ).aaggregate(
+                total=models.Sum('realized_pnl')
+            )
+            total_pnl = total_pnl_result['total'] or 0
+
+            # Check episode-level terminal conditions
+            if hasattr(daytrader_config,
+                       'EPISODE_PROFIT_TARGET') and total_pnl >= daytrader_config.EPISODE_PROFIT_TARGET:
+                return True, f"episode_profit_target_{daytrader_config.EPISODE_PROFIT_TARGET}"
+
+            elif hasattr(daytrader_config, 'EPISODE_LOSS_LIMIT') and total_pnl <= daytrader_config.EPISODE_LOSS_LIMIT:
+                return True, f"episode_loss_limit_{abs(daytrader_config.EPISODE_LOSS_LIMIT)}"
+
+            elif hasattr(daytrader_config, 'MAX_STEPS') and session.current_step >= daytrader_config.MAX_STEPS:
+                return True, f"max_steps_{daytrader_config.MAX_STEPS}"
+
+            # Session continues if no terminal conditions are met
+            return False, None
+
+        except Exception as e:
+            logger.error(f"Error checking terminal conditions for session {session_id}: {e}")
+            return False, None
+
+    def _update_trade_cache(self, trade, current_price, current_pnl):
+        """Update individual trade in cache with standardized format"""
+        try:
+            trade_data = TradeDataSerializer.serialize_trade(trade, current_price)
+
+            # Ensure P&L fields are always valid numbers
+            trade_data['current_pnl'] = round(float(current_pnl or 0), 2)
+            trade_data['pnl'] = round(float(current_pnl or 0), 2)
+            trade_data['unrealized_pnl'] = round(float(current_pnl or 0), 2)
+
+            session_trades_key = f"daytrader_active_trades:{trade.session.id}"
+            session_trades = cache.get(session_trades_key, {})
+            session_trades[trade.agent_tag] = trade_data
+            cache.set(session_trades_key, session_trades, timeout=3600)
+
+            logger.debug(f"Updated trade cache for {trade.agent_tag}: current_price={current_price}, pnl={current_pnl}")
+
+        except Exception as e:
+            logger.error(f"Error updating trade cache: {e}")
+
+    @database_sync_to_async
+    def get_all_active_trades_from_cache(self):
+        """Get active trades from Redis cache with database fallback using standardized format"""
+        try:
+            from games.models import Trade
+
+            active_trades = Trade.objects.filter(
+                is_active=True,
+                session__environment__name__icontains='daytrader'
+            ).select_related('session', 'session__environment')
+
+            trades_data = []
+            for trade in active_trades:
+                trade_data = TradeDataSerializer.serialize_trade(trade, trade.current_price)
+                trades_data.append(trade_data)
+
+            return trades_data
+        except Exception as e:
+            logger.error(f"Error getting active trades from cache: {e}")
+            return []
+
+    async def active_trades_update(self, event):
+        """Handle active trades update broadcast"""
+        try:
+            await self.send(text_data=safe_json_dumps({
+                "type": "active.trades",
+                "data": event["data"],
+                "timestamp": time.time()
+            }))
+
+        except Exception as e:
+            logger.error(f"Error sending active trades update: {e}")
+
+    async def trade_closed(self, event):
+        """Handle trade closure broadcast"""
+        try:
+            await self.send(text_data=safe_json_dumps({
+                "type": "trade.closed",
+                "data": event["data"],
+                "timestamp": time.time()
+            }))
+            logger.info(f"[v0] Broadcasted trade closure for trade {event['data'].get('trade_id', 'unknown')}")
+        except Exception as e:
+            logger.error(f"Error broadcasting trade closure: {e}", exc_info=True)
+
+    async def session_cleanup(self, event):
+        """Handle session cleanup broadcast"""
+        try:
+            await self.send(text_data=safe_json_dumps({
+                "type": "session.cleanup",
+                "data": event["data"],
+                "timestamp": time.time()
+            }))
+        except Exception as e:
+            logger.error(f"Error broadcasting session cleanup: {e}")
+
+    async def send_message(self, event):
+        """Handle messages sent from RQ workers"""
+        try:
+            data = event.get('data', event)
+            await self.send(text_data=safe_json_dumps(data))
+        except Exception as e:
+            logger.error(f"Error sending message from RQ worker: {e}")
+
+
+# Legacy GameConsumer for backward compatibility
+class GameConsumer(AsyncWebsocketConsumer):
+    """Legacy consumer - redirects to new agent consumer"""
+
+    async def connect(self):
+        await self.close(code=4005, reason="Use /ws/agent/<session_id>/ instead")
+
+    async def disconnect(self, close_code):
+        pass
+
+    async def receive(self, text_data):
+        pass
+
+
+class UnifiedSessionConsumer(AsyncWebsocketConsumer):
+    """Unified WebSocket consumer for both agents and viewers to connect to the same session stream"""
+
+    async def connect(self):
+        self.session_id = self.scope["url_route"]["kwargs"]["session_id"]
+
+        if not self.session_id or self.session_id == "new" or len(self.session_id) < 8:
+            logger.error(f"Invalid session ID: {self.session_id}")
+            await self.close(code=4000)
+            return
+
+        self.connection_type = None  # Will be set to 'agent' or 'viewer'
+        self.agent_tag = None
+        self.viewer_id = None
+        self.environment_id = None
+        self.env = None
+        self.step_count = 0
+        self.current_observation = None
+        self.total_reward = 0.0
+        self.steps = 0
+
+        from games.services import game_manager
+        self.game_manager = game_manager
+
+        normalized_session_id = self.session_id.replace('-', '_')
+        self.room_group_name = f"session_{normalized_session_id}"
+
+        logger.info(f"UnifiedSessionConsumer connecting to session: {self.session_id}")
+
+        # Join the session room group
+        await self.channel_layer.group_add(self.room_group_name, self.channel_name)
+        await self.accept()
+
+        logger.info(f"UnifiedSessionConsumer connected successfully: session_id={self.session_id}")
+
+    async def disconnect(self, close_code):
+        """Handle WebSocket disconnect for both agents and viewers"""
+        try:
+            connection_type = getattr(self, 'connection_type', None)
+            session_id = getattr(self, 'session_id', None)
+            agent_tag = getattr(self, 'agent_tag', None)
+            room_group_name = getattr(self, 'room_group_name', None)
+
+            logger.info(
+                f"UnifiedSessionConsumer disconnecting: {connection_type}, session={session_id}, code={close_code}")
+
+            # Leave room group
+            if room_group_name:
+                await self.channel_layer.group_discard(room_group_name, self.channel_name)
+
+            # Handle agent-specific cleanup
+            if connection_type == 'agent' and agent_tag and session_id:
+                from games.tasks import queue_session_cleanup
+                queue_session_cleanup(session_id, "agent_disconnect")
+                logger.info(f"Queued cleanup for agent session {session_id}")
+
+        except Exception as e:
+            logger.error(f"Error in UnifiedSessionConsumer disconnect cleanup: {e}")
+
+    async def receive(self, text_data):
+        """Handle incoming WebSocket messages"""
+        try:
+            data = json.loads(text_data)
+            message_type = data.get("type")
+
+            logger.info(f"UnifiedSessionConsumer received message: {message_type} for session {self.session_id}")
+
+            if message_type == "agent.join":
+                self.connection_type = "agent"
+                await self.handle_agent_join(data)
+            elif message_type == "viewer.join":
+                self.connection_type = "viewer"
+                await self.handle_viewer_join(data)
+            elif message_type == "agent.action":
+                if self.connection_type == "agent":
+                    await self.handle_agent_action(data)
+                else:
+                    await self.send_error("Only agents can send actions", "UNAUTHORIZED_ACTION")
+            elif message_type == "agent.reset":
+                if self.connection_type == "agent":
+                    await self.handle_agent_reset(data)
+                else:
+                    await self.send_error("Only agents can send reset requests", "UNAUTHORIZED_ACTION")
+            else:
+                logger.warning(f"Unknown message type: {message_type}")
+                await self.send_error(f"Unknown message type: {message_type}", "UNKNOWN_MESSAGE_TYPE")
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON received: {e}")
+            await self.send_error("Invalid JSON format", "INVALID_JSON")
+        except Exception as e:
+            logger.error(f"Error in receive: {e}")
+            logger.error(f"Traceback: {traceback.format_exc()}")
+            await self.send_error(f"Message processing failed: {str(e)}", "MESSAGE_PROCESSING_FAILED")
+
+    async def session_update(self, event):
+        """Handle session updates from broadcasts"""
+        data = event.get("data", event.get("message", {}))
+        await self.send(text_data=safe_json_dumps(data))
+
+    async def broadcast_game_over(self, final_reward, total_steps, termination_reason="episode_complete"):
+        """Broadcast game over to viewers"""
+        try:
+            message = {
+                "type": "game.over",
+                "session_id": self.session_id,
+                "agent_tag": self.agent_tag,
+                "final_reward": float(final_reward) if final_reward is not None else 0.0,
+                "total_steps": total_steps,
+                "termination_reason": termination_reason,
+                "timestamp": time.time()
+            }
+
+            await self.channel_layer.group_send(self.room_group_name, {
+                "type": "session_update",
+                "message": message
+            })
+
+            logger.info(f"Broadcasted game over to room {self.room_group_name}")
+
+        except Exception as e:
+            logger.error(f"Error broadcasting game over: {e}")
+
+    async def handle_agent_join(self, data):
+        """Handle agent join request"""
+        try:
+            logger.info(f"Agent joining session: {self.session_id}")
+
+            # Extract agent and environment info
+            self.agent_tag = data.get('agent_tag', 'human-player')
+            self.environment_id = data.get('environment_id', 'LunarLander-v3')
+
+            cache.set(f"gym_session_{self.session_id}", {
+                'agent_tag': self.agent_tag,
+                'environment_id': self.environment_id,
+                'created_at': timezone.now().isoformat(),
+                'status': 'active'
+            }, timeout=3600)  # 1 hour timeout
+
+            active_sessions = cache.get("active_gym_sessions", set())
+            active_sessions.add(self.session_id)
+            cache.set("active_gym_sessions", active_sessions, timeout=3600)
+
+            active_agents = cache.get(f"active_agents_{self.session_id}", [])
+            if self.agent_tag not in active_agents:
+                active_agents.append(self.agent_tag)
+                cache.set(f"active_agents_{self.session_id}", active_agents, timeout=3600)
+
+            logger.info(f"Session {self.session_id} registered in cache with agent {self.agent_tag}")
+
+            if not self.environment_id:
+                await self.send_error("Missing environment_id", "MISSING_ENVIRONMENT_ID")
+                return
+
+            logger.info(
+                f"Agent join request received for session {self.session_id} with environment {self.environment_id}")
+
+            # Check if session already exists in database
+            session_exists = await self._check_session_exists()
+
+            if not session_exists:
+                # Create new session
+                db_session = await self._create_database_session()
+
+                if db_session:
+                    # Initialize gymnasium environment
+                    await self._initialize_environment()
+
+                    # Register in cache for viewers
+                    observation, info = self.env.reset()
+                    await self._register_session_in_cache(self.environment_id, observation, info)
+
+                    # Send response to agent
+                    response = {
+                        "type": "agent.joined",
+                        "session_id": self.session_id,
+                        "observation": observation.tolist() if hasattr(observation, 'tolist') else observation,
+                        "info": info,
+                        "environment_id": self.environment_id
+                    }
+                    await self.send(text_data=json.dumps(response))
+                    logger.info(f"Agent successfully joined session {self.session_id}")
+                else:
+                    await self.send_error("Failed to create session", "SESSION_CREATION_FAILED")
+            else:
+                if not self.env:
+                    await self._initialize_environment()
+
+                # Session exists, send current state
+                observation, info = self.env.reset()
+                response = {
+                    "type": "agent.joined",
+                    "session_id": self.session_id,
+                    "observation": observation.tolist() if hasattr(observation, 'tolist') else observation,
+                    "info": info,
+                    "environment_id": self.environment_id
+                }
+                await self.send(text_data=json.dumps(response))
+                logger.info(f"Agent rejoined existing session {self.session_id}")
+
+        except Exception as e:
+            logger.error(f"Error in handle_agent_join: {e}")
+            await self.send_error(f"Failed to join as agent: {str(e)}", "AGENT_JOIN_FAILED")
+
+    async def handle_viewer_join(self, data):
+        """Handle viewer joining a session"""
+        self.viewer_id = data.get("viewer_id", f"viewer_{self.channel_name[-8:]}")
+
+        try:
+            # Check if session exists
+            session_exists = await self.check_session_exists()
+            if not session_exists:
+                logger.error(f"Session not found for viewer: {self.session_id}")
+                await self.send_error("Session not found", "SESSION_NOT_FOUND")
+                return
+
+            # Send current session state to viewer
+            session_state = await self.get_session_state()
+            response = {
+                "type": "viewer.joined",
+                "viewer_id": self.viewer_id,
+                "session_id": self.session_id,
+                "session_state": session_state,
+                "timestamp": time.time()
+            }
+
+            await self.send(text_data=safe_json_dumps(response))
+
+            # Notify other participants that a viewer joined
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {
+                    "type": "session_update",
+                    "data": {
+                        "type": "viewer.joined",
+                        "viewer_id": self.viewer_id,
+                        "timestamp": time.time()
+                    }
+                }
+            )
+
+        except Exception as e:
+            logger.error(f"Error in handle_viewer_join: {e}")
+            await self.send_error(f"Failed to join as viewer: {str(e)}", "VIEWER_JOIN_FAILED")
+
+    async def handle_agent_action(self, data):
+        """Handle agent action and broadcast to viewers"""
+        try:
+            if not self.env:
+                logger.error(f"Environment not initialized for session {self.session_id}")
+                await self.send_error("Environment not initialized", "ENV_NOT_INITIALIZED")
+                return
+
+            action = data.get("action")
+            if action is None:
+                await self.send_error("Action is required", "MISSING_ACTION")
+                return
+
+            logger.info(f"Agent {self.agent_tag} taking action {action} in session {self.session_id}")
+
+            # Take action in environment
+            observation, reward, done, truncated, info = self.env.step(action)
+
+            # Convert numpy types to Python types for JSON serialization
+            if hasattr(observation, 'tolist'):
+                observation = observation.tolist()
+
+            reward = float(reward) if reward is not None else 0.0
+            done = bool(done) if done is not None else False
+            truncated = bool(truncated) if truncated is not None else False
+
+            # Update session state
+            self.current_observation = observation
+            self.total_reward += reward
+            self.steps += 1
+
+            unified_data = {
+                "type": "action.taken",
+                "session_id": self.session_id,
+                "agent_tag": self.agent_tag,
+                "action": action,
+                "observation": observation,
+                "reward": reward,
+                "done": done,
+                "truncated": truncated,
+                "info": info,
+                "total_reward": self.total_reward,
+                "steps": self.steps,
+                "timestamp": time.time()
+            }
+
+            await self.send(text_data=safe_json_dumps(unified_data))
+
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {
+                    "type": "session_update",
+                    "data": unified_data
+                }
+            )
+
+            # Update session state in cache
+            await self._update_session_cache(observation, reward, done, info)
+
+            if done:
+                logger.info(f"Episode completed for session {self.session_id}")
+                await self.broadcast_game_over(self.total_reward, self.steps, "episode_complete")
+
+        except Exception as e:
+            logger.error(f"Error in handle_agent_action: {e}")
+            logger.error(f"Traceback: {traceback.format_exc()}")
+            await self.send_error(f"Action failed: {str(e)}", "ACTION_FAILED")
+
+    async def handle_agent_reset(self, data):
+        """Handles an agent's request to reset the environment for a new episode."""
+        if not self.env:
+            await self.send_error("Environment not initialized", "ENV_NOT_INITIALIZED")
+            return
+
+        try:
+            observation, info = self.env.reset()
+            self.total_reward = 0.0
+            self.steps = 0
+            logger.info(f"Environment reset for session {self.session_id}")
+
+            response = {
+                "type": "environment.reset",
+                "observation": observation.tolist() if hasattr(observation, 'tolist') else observation,
+                "info": info
+            }
+            await self.send(text_data=safe_json_dumps(response))
+
+        except Exception as e:
+            logger.error(f"Error resetting environment for session {self.session_id}: {e}", exc_info=True)
+            await self.send_error(f"Failed to reset environment: {str(e)}", "RESET_FAILED")
+
+    async def get_session_state(self):
+        """Get current session state for viewers"""
+        try:
+            return {
+                "session_id": self.session_id,
+                "environment_id": self.environment_id,
+                "observation": self.current_observation,
+                "total_reward": self.total_reward,
+                "steps": self.steps,
+                "agents": [{"agent_tag": self.agent_tag, "agent_type": "human"}] if self.agent_tag else [],
+                "status": "active" if self.env else "waiting",
+                "timestamp": time.time()
+            }
+        except Exception as e:
+            logger.error(f"Error getting session state: {e}")
+            return {
+                "session_id": self.session_id,
+                "status": "error",
+                "timestamp": time.time()
+            }
+
+    # Include other helper methods from AgentConsumer
+    def is_day_trader_environment(self, environment_id):
+        return "daytrader" in environment_id.lower() or "DayTrader" in environment_id
+
+    async def _create_database_session(self):
+        """Create database session record"""
+        try:
+            from games.models import GameSession, SessionAgent, Environment
+            from games.services import SessionManager
+
+            # Get or create environment
+            environment, _ = await database_sync_to_async(Environment.objects.get_or_create)(
+                env_id=self.environment_id,
+                defaults={
+                    'name': self.environment_id,
+                    'description': f'Gymnasium environment: {self.environment_id}',
+                    'category': 'custom'
+                }
+            )
+
+            try:
+                session_uuid = uuid.UUID(self.session_id)
+            except ValueError:
+                # If session_id is not a valid UUID, generate a new one
+                session_uuid = uuid.uuid4()
+                logger.warning(
+                    f"Invalid UUID format for session_id {self.session_id}, generated new UUID: {session_uuid}")
+                self.session_id = str(session_uuid)
+
+            # Create session
+            session = await database_sync_to_async(GameSession.objects.create)(
+                id=session_uuid,
+                environment=environment,
+                current_step=0,
+                total_reward=0.0,
+                is_done=False,
+                status='waiting'
+            )
+
+            await database_sync_to_async(SessionAgent.objects.create)(
+                session=session,
+                agent_tag=self.agent_tag,
+                agent_name=f"Player-{self.agent_tag[:10]}",
+                agent_type="human",
+                player_id=0,
+                is_active=True
+            )
+
+            # Mark session as active in SessionManager
+            await database_sync_to_async(SessionManager.mark_session_active)(str(session.id))
+
+            logger.info(f"Created database session: {session.id}")
+            return session
+
+        except Exception as e:
+            logger.error(f"Error creating database session: {e}")
+            raise e
+
+    async def _initialize_environment(self):
+        """Initialize gymnasium environment"""
+        try:
+            import gymnasium as gym
+            self.env = gym.make(self.environment_id)
+            logger.info(f"Initialized environment: {self.environment_id}")
+        except Exception as e:
+            logger.error(f"Error initializing environment: {e}")
+            raise
+
+    async def _register_session_in_cache(self, environment_id, observation, info):
+        """Register session in cache for viewers"""
+        try:
+            session_data = {
+                "session_id": self.session_id,
+                "environment_id": environment_id,
+                "agent_tag": self.agent_tag,
+                "observation": observation.tolist() if hasattr(observation, 'tolist') else observation,
+                "info": info,
+                "step_count": 0,
+                "total_reward": 0.0,
+                "is_done": False,
+                "timestamp": time.time()
+            }
+
+            cache.set(f"gym_session_{self.session_id}", session_data, timeout=3600)
+
+            # Add to active sessions set
+            active_sessions = cache.get("active_gym_sessions", set())
+            active_sessions.add(self.session_id)
+            cache.set("active_gym_sessions", active_sessions, timeout=3600)
+
+            logger.info(f"Registered session in cache: {self.session_id}")
+
+        except Exception as e:
+            logger.error(f"Error registering session in cache: {e}")
+
+    async def _update_session_cache(self, observation, reward, done, info):
+        """Update session state in cache"""
+        try:
+            session_data = cache.get(f"gym_session_{self.session_id}", {})
+            session_data.update({
+                "observation": observation.tolist() if hasattr(observation, 'tolist') else observation,
+                "last_reward": float(reward) if hasattr(reward, 'item') else reward,
+                "total_reward": session_data.get("total_reward", 0) + (
+                    float(reward) if hasattr(reward, 'item') else reward),
+                "step_count": self.step_count,
+                "is_done": done,
+                "info": info,
+                "timestamp": time.time()
+            })
+
+            cache.set(f"gym_session_{self.session_id}", session_data, timeout=3600)
+
+        except Exception as e:
+            logger.error(f"Error updating session cache: {e}")
+
+    async def send_error(self, message, error_code):
+        """Send error message to client"""
+        await self.send(text_data=safe_json_dumps({
+            "type": "error",
+            "message": message,
+            "error_code": error_code,
+            "timestamp": time.time()
+        }))
+
+    async def _check_session_exists(self):
+        """Check if session exists in database"""
+        try:
+            db_session = await database_sync_to_async(self.game_manager.get_session_by_id)(self.session_id)
+            if db_session:
+                return True
+            else:
+                return False
+        except Exception as e:
+            logger.error(f"Error checking session existence in database: {e}")
+            return False
+
+    async def check_session_exists(self):
+        """Check if session exists in database or as active direct gymnasium session"""
+        try:
+            logger.info(f"Checking session existence for: {self.session_id}")
+
+            session_ids_to_check = [
+                self.session_id,  # Normalized format (no hyphens)
+                f"gym_{self.session_id}",  # Add gym_ prefix
+            ]
+
+            # Check database sessions first
+            for sid in session_ids_to_check:
+                try:
+                    db_session_exists = await database_sync_to_async(game_manager.session_exists)(sid)
+                    if db_session_exists:
+                        logger.info(f"Found database session: {sid}")
+                        self.session_id = sid  # Update to the found session ID
+                        return True
+                except Exception as e:
+                    logger.debug(f"Database session check failed for {sid}: {e}")
+
+            # Check cache with multiple formats
+            for sid in session_ids_to_check:
+                # Check gymnasium session cache
+                gym_session_data = cache.get(f"gym_session_{sid}")
+                if gym_session_data:
+                    logger.info(f"Found gymnasium session in cache: {sid}")
+                    self.session_id = sid  # Update to the found session ID
+                    return True
+
+                # Check active agents cache
+                active_agents = cache.get(f"active_agents_{sid}", [])
+                if len(active_agents) > 0:
+                    logger.info(f"Found active agents for session: {sid} - agents: {active_agents}")
+                    self.session_id = sid  # Update to the found session ID
+                    return True
+
+            # Check active sessions registry
+            active_sessions = cache.get("active_gym_sessions", set())
+            for sid in session_ids_to_check:
+                if sid in active_sessions:
+                    logger.info(f"Found session in active registry: {sid}")
+                    self.session_id = sid  # Update to the found session ID
+                    return True
+
+            logger.warning(f"Session not found in any cache or database for session_id: {self.session_id}")
+            return False
+
+        except Exception as e:
+            logger.error(f"Error checking session existence: {e}")
+            return False
+
+    async def disconnect(self, close_code):
+        """Handle WebSocket disconnect"""
+        try:
+            logger.info(f"WebSocket disconnecting for session {self.session_id}, close_code: {close_code}")
+
+            if hasattr(self, 'session_id') and self.session_id:
+                # Remove from active sessions
+                active_sessions = cache.get("active_gym_sessions", set())
+                active_sessions.discard(self.session_id)
+                cache.set("active_gym_sessions", active_sessions, timeout=3600)
+
+                # Clean up agent registration
+                if hasattr(self, 'agent_tag') and self.agent_tag:
+                    active_agents = cache.get(f"active_agents_{self.session_id}", [])
+                    if self.agent_tag in active_agents:
+                        active_agents.remove(self.agent_tag)
+                        cache.set(f"active_agents_{self.session_id}", active_agents, timeout=3600)
+
+                logger.info(f"Cleaned up session {self.session_id} from cache")
+
+        except Exception as e:
+            logger.error(f"Error during disconnect: {e}")
+        finally:
+            await super().disconnect(close_code)
+You are now unblocked.
+
+You **must** respond now, using the `message_user` tool.
+System Info: timestamp: 2025-08-23 01:12:47.382436

--- a/backend/colosseum_connector.py
+++ b/backend/colosseum_connector.py
@@ -68,6 +68,18 @@ class ColosseumConnector:
             logger.error(f"An unexpected error occurred during WebSocket connection: {e}", exc_info=True)
             return False
 
+    async def send_message(self, message):
+        """Sends a raw JSON message to the server."""
+        if not self.websocket:
+            logger.error("Cannot send message, WebSocket is not connected.")
+            return
+        try:
+            await self.websocket.send(json.dumps(message))
+        except websockets.exceptions.ConnectionClosed:
+            logger.warning("Cannot send message, connection is closed.")
+        except Exception as e:
+            logger.error(f"Failed to send message: {e}", exc_info=True)
+
     async def join_session(self):
         """Sends the agent.join message to formally join the session."""
         if not self.websocket:

--- a/backend/storage/test-hub-agent_history/history.json
+++ b/backend/storage/test-hub-agent_history/history.json
@@ -94,5 +94,13 @@
     "info": {
       "message": "Initial state."
     }
+  },
+  {
+    "version": 12,
+    "type": "diff",
+    "timestamp": "2025-08-23T08:14:31.245941",
+    "info": {
+      "message": "Initial state."
+    }
   }
 ]


### PR DESCRIPTION
This commit implements a mechanism to allow a training agent to run multiple episodes within a single, persistent session. This addresses the issue where the training script would create a new session for every episode, which was inefficient.

The following changes are included:
1.  **Server-side Consumer:** A new `agent.reset` message handler has been added to the `UnifiedSessionConsumer`. When a client sends this message, the server resets the gymnasium environment and sends back the new initial observation.
2.  **Client-side Connector:** A generic `send_message` method has been added to the `ColosseumConnector` to allow sending non-action messages like the new reset command.
3.  **Training Script:** The `train_agent.py` script has been refactored. It now establishes a single session at the beginning of the training run. Between episodes, it sends the `agent.reset` message to the server to start a new episode, instead of disconnecting and creating a new session.