### PR TITLE
feat: Add masked action selection for valid actions

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -95,6 +95,15 @@ class Command(BaseCommand):
         total_rewards = []
         current_obs = np.array(join_response.get("observation"))
 
+        # Get the actual action space size from the environment info
+        try:
+            actual_action_dim = join_response['info']['action_space']['n']
+            logger.info(f"Environment action space size: {actual_action_dim}")
+        except (KeyError, TypeError):
+            logger.warning("Could not determine actual action space size from server. Defaulting to max.")
+            actual_action_dim = max_action_dim
+
+
         try:
             with tqdm(total=num_episodes, desc="Training on Colosseum") as pbar:
                 for episode in range(num_episodes):
@@ -104,7 +113,7 @@ class Command(BaseCommand):
                     # --- Gameplay Loop for one episode ---
                     while not done:
                         agent.perceive_and_update_state("vector_input", current_obs)
-                        action, log_prob, stag_context = agent.select_action()
+                        action, log_prob, stag_context = agent.select_action(actual_action_dim)
 
                         await connector.send_action(action)
                         msg = await connector.receive_message()

--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -189,10 +189,11 @@ class ChimeraAgent:
 
         return self.hidden_state
 
-    def select_action(self):
+    def select_action(self, actual_action_dim):
         """
         Selects an action based on the current internal state of the agent,
-        now augmented with context from the STAG knowledge graph.
+        augmented with context from the STAG knowledge graph, and constrained
+        by the actual action space of the environment.
         """
         internal_state = self.hidden_state
         h_numpy = internal_state.detach().numpy().flatten()
@@ -213,13 +214,16 @@ class ChimeraAgent:
         with torch.no_grad():
             action_logits = self.action_head(combined_input).squeeze(0)
 
+        # Mask the logits to only consider valid actions for the current environment
+        valid_logits = action_logits[:actual_action_dim]
+
         # Convert to numpy for softmax and sampling
-        action_probs_np = softmax(action_logits.numpy())
-        action = np.random.choice(self.max_action_dim, p=action_probs_np)
+        action_probs_np = softmax(valid_logits.numpy())
+        action = np.random.choice(actual_action_dim, p=action_probs_np)
         action_tensor = torch.tensor(action)
 
         # We need the log_prob as a tensor for the loss calculation
-        log_probs = torch.nn.functional.log_softmax(action_logits, dim=-1)
+        log_probs = torch.nn.functional.log_softmax(valid_logits, dim=-1)
         action_log_prob = log_probs[action]
 
         # Store the chosen action for the next world model update


### PR DESCRIPTION
- Modifies `ChimeraAgent.select_action` to accept the environment's actual action dimension and mask its output logits accordingly.
- Updates `train_agent.py` to get the action dimension from the server and pass it to the agent.
- This prevents the agent from selecting actions that are outside the valid range for the current environment.