### PR TITLE
fix: Mask action selection to prevent invalid actions

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -96,9 +96,8 @@ class Command(BaseCommand):
         current_obs = np.array(join_response.get("observation"))
 
         # Get the actual action space size from the environment info
-        logger.info(f"Full join response from server: {join_response}")
         try:
-            actual_action_dim = join_response['info']['action_space']['n']
+            actual_action_dim = join_response['action_space_shape']
             logger.info(f"Environment action space size: {actual_action_dim}")
         except (KeyError, TypeError):
             logger.warning("Could not determine actual action space size from server. Defaulting to max.")


### PR DESCRIPTION
- Updates `train_agent.py` to correctly parse the action space size from the server's `join_response`.
- Passes the actual action dimension to the `select_action` method.
- Modifies `select_action` to mask the output logits, ensuring that the agent only chooses actions that are valid for the current environment.