### PR TITLE
fix: Pad observation batches in training and adjust save frequency

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -135,7 +135,8 @@ class Command(BaseCommand):
 
                     # --- Post-Episode ---
                     train_stats = agent.train()
-                    agent.save_state(version_info=train_stats)
+                    if (episode + 1) % 50 == 0:
+                        agent.save_state(version_info=train_stats)
                     total_rewards.append(episode_reward)
 
                     avg_reward = np.mean(total_rewards[-100:])

--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -251,10 +251,21 @@ class ChimeraAgent:
         # Detach hidden states before stacking to prevent gradients from flowing back
         hidden_state_batch = torch.stack([h.detach() for h in batch.hidden_state]).squeeze(1)
         stag_context_batch = torch.stack([s.detach() for s in batch.stag_context]).squeeze(1)
-        obs_batch = torch.stack([torch.from_numpy(o) for o in batch.obs]).float()
+
+        # Pad observations to max_obs_dim
+        def pad_observations(obs_list):
+            padded_obs = []
+            for o in obs_list:
+                padded = np.zeros(self.max_obs_dim)
+                padded[:o.shape[0]] = o
+                padded_obs.append(padded)
+            return torch.from_numpy(np.array(padded_obs)).float()
+
+        obs_batch = pad_observations(batch.obs)
+        next_obs_batch = pad_observations(batch.next_obs)
+
         action_batch = torch.tensor(batch.action)
         reward_batch = torch.tensor(batch.reward).float()
-        next_obs_batch = torch.stack([torch.from_numpy(o) for o in batch.next_obs]).float()
         done_batch = torch.tensor(batch.done).float()
 
         # --- Initialize ---


### PR DESCRIPTION
- Modifies the `train` method in `chimera_agent.py` to pad observation batches to the agent's max observation dimension. This prevents a `RuntimeError` from dimension mismatches during training.
- Updates the training loop in `train_agent.py` to only save the agent's state every 50 episodes.