### PR TITLE
fix: Normalize GNG input in select_action to prevent overflow

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -206,6 +206,11 @@ class ChimeraAgent:
         internal_state = self.hidden_state
         h_numpy = internal_state.detach().numpy().flatten()
 
+        # Normalize the hidden state vector before passing it to the STAG
+        h_norm = np.linalg.norm(h_numpy)
+        if h_norm > 0:
+            h_numpy = h_numpy / h_norm
+
         # Find the current conceptual context from the STAG
         terminal_level_node, winner_id, _ = self.stag.find_terminal_node_and_path(h_numpy)
 


### PR DESCRIPTION
The `select_action` method in `chimera_agent.py` was passing an unnormalized hidden state vector to the STAG framework, which in turn used it as input for the GNG engine. This caused the GNG node weights to grow uncontrollably, leading to a numerical overflow and `NaN` values in the action probabilities.

This change adds the same normalization logic that is present in `perceive_and_update_state` to the `select_action` method. This ensures that the GNG engine always receives a normalized input vector, preventing the overflow and resolving the subsequent crash.