### PR TITLE
fix: Normalize GNG inputs and weights to prevent overflow

### DIFF
--- a/backend/api/services/gng_engine.py
+++ b/backend/api/services/gng_engine.py
@@ -59,6 +59,12 @@ class GNG_Engine:
 
     def _add_node(self, weight_vector, error=0.0, utility=1.0):
         node_id = self._next_node_id
+
+        # Normalize the weight vector to have a length of 1
+        norm = np.linalg.norm(weight_vector)
+        if norm > 0:
+            weight_vector = weight_vector / norm
+
         self.nodes[node_id] = {
             'weight': weight_vector.astype('float32'),
             'error': error,
@@ -91,11 +97,23 @@ class GNG_Engine:
         dynamic_winner_lr = self.winner_learning_rate / (1e-5 + np.log1p(winner_utility))
         self.nodes[s1_id]['weight'] += dynamic_winner_lr * (input_vector - self.nodes[s1_id]['weight'])
 
+        # Re-normalize the winner's weight vector
+        winner_weight = self.nodes[s1_id]['weight']
+        norm = np.linalg.norm(winner_weight)
+        if norm > 0:
+            self.nodes[s1_id]['weight'] = winner_weight / norm
+
         neighbor_ids = self._get_neighbors(s1_id)
         for n_id in neighbor_ids:
             neighbor_utility = self.nodes[n_id]['utility']
             dynamic_neighbor_lr = self.neighbor_learning_rate / (1e-5 + np.log1p(neighbor_utility))
             self.nodes[n_id]['weight'] += dynamic_neighbor_lr * (input_vector - self.nodes[n_id]['weight'])
+
+            # Re-normalize the neighbor's weight vector
+            neighbor_weight = self.nodes[n_id]['weight']
+            norm = np.linalg.norm(neighbor_weight)
+            if norm > 0:
+                self.nodes[n_id]['weight'] = neighbor_weight / norm
 
         self.faiss_index = None # Invalidate index due to weight changes
 


### PR DESCRIPTION
This commit applies two fixes to prevent numerical instability in the GNG engine:

1.  **Normalize GNG input in `select_action`:** The `select_action` method in `chimera_agent.py` was passing an unnormalized hidden state vector to the GNG engine. This could cause the node weights to grow uncontrollably, leading to numerical overflow and `NaN` values in action probabilities. The hidden state vector is now normalized before being passed to the GNG.

2.  **Enforce GNG weight normalization:** The GNG engine in `gng_engine.py` has been modified to enforce that all node weight vectors are normalized to a length of 1. This is done by:
    - Normalizing the weight vector of any newly created node.
    - Re-normalizing the weight vectors of the winning node and its neighbors immediately after their weights are updated.

These changes ensure that the GNG engine operates with normalized vectors, preventing overflows and improving the stability of the agent's learning process.