### PR TITLE
Feat: Implement architectural enhancements for training stability.

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -105,6 +105,49 @@ class Command(BaseCommand):
             actual_action_dim = max_action_dim
 
 
+        burnin_steps = agent_config.get('hyperparams', {}).get('burnin_steps', 1000)
+        logger.info(f"Starting burn-in phase for {burnin_steps} steps...")
+        for _ in tqdm(range(burnin_steps), desc="Burn-in"):
+            # Perceive the environment to get the latest state for the replay buffer
+            _, _, _, activation_path, novelty = agent.perceive_and_update_state("vector_input", current_obs)
+
+            # Take a random action
+            action = np.random.randint(0, actual_action_dim)
+            await connector.send_action(action)
+            msg = await connector.receive_message()
+
+            if not msg or msg.get("type") != "action.taken":
+                if msg and msg.get("type") == "game.over":
+                    reset_response = await connector.reset_environment()
+                    if reset_response:
+                        current_obs = np.array(reset_response.get("observation"))
+                continue
+
+            next_obs = np.array(msg.get("observation"))
+            external_reward = msg.get("reward", 0)
+            done = msg.get("done", False)
+
+            # Store the random experience in the replay buffer
+            # Use dummy values for log_prob as the action was random
+            agent.record_experience(
+                agent.hidden_state,
+                agent.latent_state,
+                activation_path,
+                current_obs,
+                action,
+                torch.tensor(0.0), # Dummy log_prob
+                external_reward, # Use external reward directly
+                next_obs,
+                done
+            )
+
+            current_obs = next_obs
+            if done:
+                reset_response = await connector.reset_environment()
+                if reset_response:
+                    current_obs = np.array(reset_response.get("observation"))
+
+
         try:
             with tqdm(total=num_episodes, desc="Training on Colosseum") as pbar:
                 for episode in range(num_episodes):

--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -117,6 +117,7 @@ class ChimeraAgent:
 
         # --- Initialize Agent State and Components ---
         self.steps_done = 0
+        self.train_steps = 0
         # h_t and z_t for the RSSM
         self.hidden_state = torch.zeros(1, self.hidden_dim)
         self.latent_state = torch.zeros(1, self.latent_dim)
@@ -347,11 +348,15 @@ class ChimeraAgent:
         The main training loop that orchestrates the "sleep" phase of the agent,
         which involves training the world model and then training the policy in imagination.
         """
+        self.train_steps += 1
         # Part 1: Train the World Model on real, recently collected data.
         world_model_stats = self.train_world_model(cortex_id)
+        policy_stats = {}
 
-        # Part 2: Train the Actor-Critic policy in imagined trajectories.
-        policy_stats = self.train_policy_in_imagination()
+        # Part 2: Train the Actor-Critic policy in imagined trajectories, but less frequently.
+        policy_train_frequency = self.hyperparams.get('policy_train_frequency', 1)
+        if self.train_steps % policy_train_frequency == 0:
+            policy_stats = self.train_policy_in_imagination()
 
         # Combine stats for logging
         combined_stats = {**world_model_stats, **policy_stats}
@@ -513,7 +518,7 @@ class ChimeraAgent:
         lambda_returns = []
         for t in reversed(range(horizon)):
             # V_target = r_t + gamma * ( (1-lambda) * V(s_{t+1}) + lambda * V_target_{t+1} )
-            returns = imagined_rewards[t] + self.gamma * ((1 - lambda_) * imagined_values[t+1] + lambda_ * returns)
+            returns = imagined_rewards[t] + self.gamma * ((1 - lambda_) * imagined_values[t+1].detach() + lambda_ * returns)
             lambda_returns.append(returns)
         lambda_returns = torch.stack(list(reversed(lambda_returns)))
 

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -43,3 +43,5 @@ agent_config:
     epsilon_start: 0.9
     epsilon_end: 0.05
     epsilon_decay_steps: 20000
+    burnin_steps: 1000
+    policy_train_frequency: 10


### PR DESCRIPTION
- Implemented a stop gradient on the critic's target value in the lambda-return calculation to stabilize critic updates.
- Introduced a burn-in period to populate the replay buffer with random experiences before training begins.
- Decoupled the world model and policy training frequency to further improve stability. A `policy_train_frequency` hyperparameter has been added.