### PR TITLE
Feat: Add option to disable internal rewards.

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -177,8 +177,12 @@ class Command(BaseCommand):
                             done = msg.get("done")
 
                             # Get internal reward and update vitals
-                            internal_reward = agent.get_internal_reward(damage_taken=0, novelty_signal=novelty)
-                            total_reward = external_reward + internal_reward
+                            use_internal_reward = agent.hyperparams.get('use_internal_reward', True)
+                            if use_internal_reward:
+                                internal_reward = agent.get_internal_reward(damage_taken=0, novelty_signal=novelty)
+                                total_reward = external_reward + internal_reward
+                            else:
+                                total_reward = external_reward
 
                             # Record experience with the combined, immediate reward
                             agent.record_experience(

--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -1,7 +1,7 @@
 # Configuration for training the ChimeraAgent
 
 # Environment settings
-env_name: "LunarLander-v2"
+env_name: "MountainCar-v0"
 
 # Agent settings
 default_agent_id_prefix: "Kymera-"
@@ -45,3 +45,4 @@ agent_config:
     epsilon_decay_steps: 20000
     burnin_steps: 1000
     policy_train_frequency: 10
+    use_internal_reward: false


### PR DESCRIPTION
- Added a `use_internal_reward` hyperparameter to `config.yaml`.
- Modified `train_agent.py` to conditionally use the internal reward system based on this hyperparameter.
- Updated the default `config.yaml` to use `MountainCar-v0` and disable internal rewards to test on a sparse reward environment.