### PR TITLE
Fix: Correctly process batches in DenseCortex.

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -396,7 +396,7 @@ class ChimeraAgent:
         next_obs_batch_raw = pad_observations(batch.next_obs)
 
         # Process observations through the cortex
-        obs_batch_processed = torch.from_numpy(cortex.process(next_obs_batch_raw.numpy())).float()
+        obs_batch_processed = cortex(next_obs_batch_raw) # Note: we are predicting the *next* observation
 
         h_prev_batch = torch.stack(batch.h).squeeze(1)
         z_prev_batch = torch.stack(batch.z).squeeze(1)


### PR DESCRIPTION
- Reverted a previous incorrect change in `train_world_model`.
- The `DenseCortex` is a `torch.nn.Module` and its `forward` method should be used for batch processing. The `process` method is only for single instances.
- Calling `cortex.process()` on a batch was causing a `ValueError` due to incorrect padding logic for batches.
- The code now correctly calls the `forward` method by using `cortex(batch_tensor)`.