### PR TITLE
fix: Correct data access pattern for dynamic cortex selection

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -79,14 +79,14 @@ class Command(BaseCommand):
         # --- Dynamically configure agent based on environment specs ---
         try:
             # Reconstruct the observation space from the server's response
-            obs_space_info = join_response['observation_space']
+            obs_space_info = join_response['environment']['observation_space']
             observation_space = gym.spaces.Box(
                 low=np.array(obs_space_info['low']),
                 high=np.array(obs_space_info['high']),
                 shape=obs_space_info['shape'],
                 dtype=np.dtype(obs_space_info['dtype'])
             )
-            actual_action_dim = join_response['action_space_shape']
+            actual_action_dim = join_response['environment']['action_space']['n']
 
             cortex_configs, cortex_id = create_cortex_configs_from_observation_space(observation_space)
             logger.info(f"Dynamically configured cortex: '{cortex_id}' for observation space {observation_space}")


### PR DESCRIPTION
This commit fixes a KeyError that occurred in `train_agent.py` when attempting to configure the agent's cortex. The script was trying to access `observation_space` from the top level of the server's JSON response, but it was nested under the `environment` key.

- Modified `train_agent.py` to correctly access `join_response['environment']['observation_space']` and `join_response['environment']['action_space']['n']`.

This change ensures that the dynamic cortex selection mechanism can function correctly when the agent is run via the `train_agent` management command.