### PR TITLE
fix: Increase timeout for environment reset

### DIFF
--- a/backend/colosseum_connector.py
+++ b/backend/colosseum_connector.py
@@ -133,7 +133,7 @@ class ColosseumConnector:
 
         # Wait for the 'environment.reset' confirmation, ignoring other messages.
         start_time = asyncio.get_event_loop().time()
-        timeout = 10.0
+        timeout = 30.0  # Increased timeout for slower environments
         while asyncio.get_event_loop().time() - start_time < timeout:
             try:
                 # Use a shorter timeout for each recv() call within the main loop
@@ -144,7 +144,7 @@ class ColosseumConnector:
                     return response
                 elif response:
                     # Log other messages received while waiting
-                    logger.debug(f"Ignoring buffered message while waiting for reset confirmation: {response.get('type')}")
+                    logger.debug(f"Ignoring buffered message of type '{response.get('type')}' while waiting for reset confirmation. Content: {response}")
                 # If response is None (due to connection closed), the loop will continue and eventually time out.
 
             except asyncio.TimeoutError:


### PR DESCRIPTION
This commit addresses an error where the agent would time out waiting for an environment reset confirmation from the Colosseum server, especially with complex, slow-to-load environments.

- In `colosseum_connector.py`, the timeout in the `reset_environment` method has been increased from 10 to 30 seconds.
- Added more descriptive logging to the same method to better diagnose any future timeout issues by showing the content of ignored messages.