### PR TITLE
fix: Slow down epsilon decay for longer exploration

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -42,7 +42,7 @@ agent_config:
     # Epsilon-greedy exploration
     epsilon_start: 0.9
     epsilon_end: 0.05
-    epsilon_decay_steps: 20000
+    epsilon_decay_steps: 200000
     burnin_steps: 1000
     policy_train_frequency: 10
     use_internal_reward: false


### PR DESCRIPTION
This commit adjusts the epsilon-greedy exploration schedule to be less aggressive. The previous decay rate caused the agent to stop exploring too quickly.

- In `config.yaml`, the `epsilon_decay_steps` hyperparameter has been increased from 20,000 to 200,000.

This change will make the agent's exploration rate (epsilon) decrease ten times more slowly, giving it a significantly longer period to discover effective strategies before primarily exploiting its existing knowledge.