### PR TITLE
fix: Ensure StagContextProcessor output is always 2D

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -56,7 +56,8 @@ class StagContextProcessor(nn.Module):
             return torch.zeros(1, self.processor.out_features) # Return a zero vector if path is empty
 
         concatenated_weights = torch.cat(activation_path_weights, dim=0)
-        return self.processor(concatenated_weights.unsqueeze(0))
+        # Ensure the tensor is flat before adding the batch dimension
+        return self.processor(concatenated_weights.flatten().unsqueeze(0))
 
 
 def _initialize_cortexes(configs, output_dim, device):


### PR DESCRIPTION
This resolves a `RuntimeError` where a `torch.cat` operation would fail due to a tensor dimension mismatch (3D vs 2D).

The `StagContextProcessor` could, in some cases, produce a 3D tensor if the weights from the STAG nodes were not 1D vectors. By explicitly calling `.flatten()` on the concatenated weights before adding the batch dimension, we ensure that the input to the linear layer is always a 2D tensor, which in turn guarantees that the processor's output is 2D. This resolves the downstream dimension mismatch.