### PR TITLE
debug: Add extensive logging to train_policy_in_imagination

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -663,6 +663,7 @@ class ChimeraAgent:
         Trains the Actor (ActionHead) and Critic (ValueHead) in imagination.
         This is the second part of the "Sleep" phase.
         """
+        logger.info("--- Starting policy training in imagination ---")
         batch_size = self.hyperparams.get('batch_size', 32)
         if len(self.replay_buffer) < self.replay_buffer.sequence_length:
             return {}
@@ -682,6 +683,8 @@ class ChimeraAgent:
         h_start = torch.from_numpy(batch['h'][:, 0]).float().to(self.device)
         z_start = torch.from_numpy(batch['z'][:, 0]).float().to(self.device)
         goal_sequence = torch.from_numpy(batch['goal'][:, 0]).float().to(self.device)
+        logger.info(f"Initial h_start shape: {h_start.shape}")
+        logger.info(f"Initial z_start shape: {z_start.shape}")
 
         # --- Imagine Trajectories ---
         h_t, z_t = h_start, z_start
@@ -691,12 +694,14 @@ class ChimeraAgent:
         imagined_stag_contexts = []
 
         # --- Imagine Trajectories with Dynamic STAG Context ---
-        for _ in range(horizon):
+        for t in range(horizon):
+            logger.info(f"--- Imagination step {t} ---")
+            logger.info(f"  h_t shape at start of loop: {h_t.shape}")
             # 1. Generate STAG context dynamically for the current imagined state h_t
             # This part needs to have gradient tracking for the StagContextProcessor
             stag_contexts = []
             for i in range(h_t.size(0)): # Process each state in the batch
-                h_numpy = h_t[i].detach().numpy().flatten()
+                h_numpy = h_t[i].detach().cpu().numpy().flatten()
                 norm = np.linalg.norm(h_numpy)
                 h_normalized = h_numpy / norm if norm > 0 else h_numpy
 
@@ -713,9 +718,13 @@ class ChimeraAgent:
                 while len(path_weights) < self.max_stag_path_length:
                     path_weights.append(torch.zeros(self.hidden_dim, device=self.device))
 
-                stag_contexts.append(self.stag_context_processor(path_weights))
+                processor_output = self.stag_context_processor(path_weights)
+                if i == 0:
+                    logger.info(f"  StagContextProcessor output shape for one item: {processor_output.shape}")
+                stag_contexts.append(processor_output)
 
             stag_context_batch = torch.cat(stag_contexts, dim=0)
+            logger.info(f"  stag_context_batch shape after cat: {stag_context_batch.shape}")
 
             # If STAG is disabled for training OR we are in the pre-training phase,
             # use a zero vector for the context.
@@ -723,16 +732,21 @@ class ChimeraAgent:
                 stag_context_batch = torch.zeros_like(stag_context_batch)
 
             # 2. Actor selects action based on h_t and the dynamically generated C_t
-            # Speculative fix: Squeeze h_t if it has an extra dimension, as it's the likely culprit for the 3D vs 2D tensor error.
-            h_t_squeezed = h_t.squeeze(0) if h_t.dim() == 3 else h_t
-            action_input = torch.cat([h_t_squeezed, stag_context_batch], dim=-1)
+            logger.info(f"  Shape of h_t before torch.cat: {h_t.shape}")
+            logger.info(f"  Shape of stag_context_batch before torch.cat: {stag_context_batch.shape}")
+            action_input = torch.cat([h_t, stag_context_batch], dim=-1)
+            logger.info(f"  action_input shape: {action_input.shape}")
+
             action_dist = self.action_head(action_input, goal_sequence)
             action = action_dist.sample()
+            logger.info(f"  action shape: {action.shape}")
 
             # 3. World model predicts next state (do this without tracking gradients)
             with torch.no_grad():
                 h_t, prior_mean, prior_std = self.world_models[0].rssm.transition_model(z_t, action, h_t)
                 z_t = Normal(prior_mean, prior_std).rsample()
+                logger.info(f"  h_t shape after transition_model: {h_t.shape}")
+                logger.info(f"  z_t shape after rsample: {z_t.shape}")
 
             imagined_h.append(h_t)
             imagined_z.append(z_t)


### PR DESCRIPTION
This commit instruments the `train_policy_in_imagination` function with extensive logging of tensor shapes.

This is a debugging step to diagnose a persistent `RuntimeError` related to a tensor dimension mismatch. The logs will show the exact shapes of the tensors at each step of the imagination loop, which will allow for a precise diagnosis and a definitive fix.