### PR TITLE
refactor: Move action time to progress bar and clean up logs

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -186,7 +186,7 @@ class Command(BaseCommand):
                     while not done:
                         # 1. Perceive and Select Action
                         _, _, _, activation_path, novelty = agent.perceive_and_update_state(cortex_id, current_obs)
-                        action, log_prob, stag_context, decision_maker, epsilon = agent.select_action(actual_action_dim, activation_path)
+                        action, log_prob, stag_context, decision_maker, epsilon, action_time = agent.select_action(actual_action_dim, activation_path)
 
                         # 2. Step the environment
                         await connector.send_action(action)
@@ -271,6 +271,7 @@ class Command(BaseCommand):
                         "Energy": f"{agent.energy:.1f}",
                         "Integrity": f"{agent.integrity:.1f}",
                         "Decision": decision_maker,
+                        "Action Time": f"{action_time:.4f}s",
                         "Action Prob": f"{torch.exp(log_prob).item():.3f}",
                         "Policy Loss": self._safe_format(train_stats.get('policy_loss'), '.4f')
                     })

--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -468,8 +468,8 @@ class ChimeraAgent:
         action = action_tensor.item()
         # Ensure last_action is always a 1D tensor of shape (1,) for consistency.
         self.last_action = action_tensor.reshape(1)
-        print(f"Total select_action time: {time.time() - start_time:.4f}s, decision_maker: {decision_maker}")
-        return action, log_prob, stag_context_vector, decision_maker, epsilon
+        action_time = time.time() - start_time
+        return action, log_prob, stag_context_vector, decision_maker, epsilon, action_time
 
     def _get_epsilon(self):
         epsilon_start = self.hyperparams.get('epsilon_start', 0.9)


### PR DESCRIPTION
This commit addresses a user request to clean up the console output during training.

- The `select_action` method in `chimera_agent.py` no longer prints the action time directly to the console. Instead, it returns the timing information.
- The `train_agent.py` script now receives this timing information and incorporates it into the `tqdm` progress bar under the 'Action Time' key.

This change provides the same information to the user in a much cleaner and more integrated way, improving the overall user experience during training.