### PR TITLE
fix: Resolve multiple runtime errors and clean up logging

### DIFF
--- a/backend/api/services/per_sequence_buffer.py
+++ b/backend/api/services/per_sequence_buffer.py
@@ -14,7 +14,15 @@ class SegmentTree:
 
     def _propagate(self, idx):
         parent = (idx - 1) // 2
-        self.tree[parent] = self.tree[2 * parent + 1] + self.tree[2 * parent + 2]
+        left_child = 2 * parent + 1
+        right_child = left_child + 1
+
+        if right_child < len(self.tree):
+            self.tree[parent] = self.tree[left_child] + self.tree[right_child]
+        else:
+            # Handle cases where there is no right child
+            self.tree[parent] = self.tree[left_child]
+
         if parent > 0:
             self._propagate(parent)
 


### PR DESCRIPTION
This commit includes several fixes for issues discovered during a debugging session:

1.  **Fix `IndexError` in PER buffer**: The `SegmentTree` in `per_sequence_buffer.py` could raise an `IndexError` when the buffer capacity was not a power of two. The `_propagate` method has been made robust by adding a bounds check for the right child.

2.  **Fix `TypeError` in GraphPlanner**: The planner's heuristic function would fail if it received node weights as lists instead of NumPy arrays. The function now explicitly converts weights to `np.array()` before calculations.

3.  **Fix Dimension Mismatch in Imagination**: A `RuntimeError` was occurring due to a dimension mismatch. The root cause was that initial hidden states from the replay buffer had an extra dimension. The fix squeezes this dimension out upon sampling.

4.  **Refactor Logging**: Per user request, verbose stage timing logs have been removed from the console output. The action selection time is now returned from the `select_action` method and displayed in the `tqdm` progress bar for a cleaner UI.