### PR TITLE
fix: Resolve AttributeError for register_buffer in ChimeraAgent

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -228,9 +228,9 @@ class ChimeraAgent:
         # MoCo-style queue for contrastive learning
         self.contrastive_queue_size = self.hyperparams.get('contrastive_queue_size', 4096)
         if self.contrastive_queue_size > 0:
-            self.register_buffer("contrastive_queue", torch.randn(self.contrastive_queue_size, self.hidden_dim))
+            self.contrastive_queue = torch.randn(self.contrastive_queue_size, self.hidden_dim, device=self.device)
             self.contrastive_queue = F.normalize(self.contrastive_queue, dim=1)
-            self.register_buffer("contrastive_queue_ptr", torch.zeros(1, dtype=torch.long))
+            self.contrastive_queue_ptr = torch.zeros(1, dtype=torch.long, device=self.device)
 
         # KL Balancing
         self.use_kl_balancing = self.hyperparams.get('kl_balancing', True)


### PR DESCRIPTION
Corrects an `AttributeError` caused by calling `register_buffer` on the `ChimeraAgent` class, which does not inherit from `torch.nn.Module`.

The fix replaces the `register_buffer` calls for `contrastive_queue` and `contrastive_queue_ptr` with direct tensor initializations on the correct device. This approach is consistent with how other tensors are managed within the agent and aligns with the manual handling of these buffers in the `save_state` and `load_state` methods.