### PR TITLE
fix: Prevent KeyError in STAG graph flattening

### DIFF
--- a/backend/api/services/stag_framework.py
+++ b/backend/api/services/stag_framework.py
@@ -144,8 +144,8 @@ class STAG_Framework:
                     'level_id': level_id,
                     'gng_node_id': node_id,
                     'weight': node_data['weight'].tolist(),
-                    'error': node_data['error'],
-                    'utility': node_data['utility']
+                    'error': node_data.get('error', 0.0),
+                    'utility': node_data.get('utility', 0.0)
                 }
                 final_nodes[global_id] = serializable_node
                 node_id_counter += 1


### PR DESCRIPTION
Resolves a `KeyError: 'error'` that occurs in `stag_framework.py` within the `get_flattened_structure` method.

The error was caused by directly accessing the 'error' and 'utility' keys on a GNG node's data dictionary. These keys may not exist for newly created nodes, leading to a crash.

This commit makes the code more robust by using the `.get()` method with a default value of `0.0` for both 'error' and 'utility'. This ensures that the graph can be flattened for the planner even when it contains uninitialized nodes.