### PR TITLE
fix: Correct NameError and AttributeError in train_agent

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -6,6 +6,7 @@ import yaml
 import logging
 import asyncio
 import pprint
+import random
 from tqdm import tqdm
 from django.core.management.base import BaseCommand
 from api.services.chimera_agent import ChimeraAgent
@@ -386,7 +387,7 @@ class Command(BaseCommand):
                     pbar.set_postfix(postfix_metrics)
 
                     # Environment reset is handled by the game server on 'done'
-                    if not await connector.is_connected():
+                    if not connector.websocket or connector.websocket.closed:
                         logger.error("Lost connection to server. Stopping training.")
                         break
 


### PR DESCRIPTION
This commit addresses two separate errors in `backend/api/management/commands/train_agent.py`:

1.  Resolves a `NameError: name 'random' is not defined` by adding the missing `import random` statement.
2.  Resolves an `AttributeError: 'ColosseumConnector' object has no attribute 'is_connected'` by replacing the incorrect method call with a check on the `connector.websocket.closed` attribute. This is the proper way to check the connection status as implemented in the `ColosseumConnector` class.