### PR TITLE
perf: Optimize GraphPlanner with adjacency list

### DIFF
--- a/backend/api/services/action/graph_planner.py
+++ b/backend/api/services/action/graph_planner.py
@@ -116,14 +116,8 @@ class GraphPlanner:
         return ((weight1 - weight2)**2).sum()**0.5
 
     def _get_neighbors(self, node_id, stag_graph):
-        """Returns the neighbors of a node in the STAG graph."""
-        neighbors = set()
-        for edge in stag_graph['edges']:
-            if edge['source'] == node_id:
-                neighbors.add(edge['target'])
-            elif edge['target'] == node_id:
-                neighbors.add(edge['source'])
-        return neighbors
+        """Returns the neighbors of a node using the pre-computed adjacency list."""
+        return stag_graph['adj'].get(node_id, [])
 
     def _reconstruct_path(self, came_from, current_node_id):
         """Reconstructs the path from the came_from dictionary."""

--- a/backend/api/services/stag_framework.py
+++ b/backend/api/services/stag_framework.py
@@ -178,9 +178,16 @@ class STAG_Framework:
 
         traverse(self.tree)
 
+        # Create adjacency list for efficient lookups
+        adj_list = {node_id: [] for node_id in final_nodes}
+        for edge in final_edges:
+            adj_list[edge['source']].append(edge['target'])
+            adj_list[edge['target']].append(edge['source'])
+
         return {
             'nodes': final_nodes,
             'edges': final_edges,
+            'adj': adj_list,
             'dimensions': self.dimensions
         }
 


### PR DESCRIPTION
Improves the performance of the `GraphPlanner` by pre-computing an adjacency list for the skill graph. This significantly speeds up neighbor lookups during pathfinding algorithms.

Changes:
- The `get_flattened_structure` method in `stag_framework.py` now computes and includes an adjacency list (`adj`) in the returned graph structure.
- The `_get_neighbors` method in `graph_planner.py` has been updated to use this adjacency list, changing neighbor lookups from a slow O(E) iteration to an efficient O(1) dictionary access.

This optimization will reduce the time spent in the planning phase and improve the overall steps-per-second of the agent's training loop, especially as the skill graphs grow in complexity.