### PR TITLE
fix: Resolve TypeError in SkillManager deserialization

### DIFF
--- a/backend/api/services/skill_manager.py
+++ b/backend/api/services/skill_manager.py
@@ -120,6 +120,8 @@ class SkillManager:
         if dimensions is None:
             raise ValueError("SkillManager deserialization failed: 'dimensions' is None.")
 
+        # Avoid passing 'dimensions' as a keyword argument if it's already being passed positionally.
+        kwargs.pop('dimensions', None)
         manager = cls(dimensions, **kwargs)
 
         # Load skill graphs


### PR DESCRIPTION
This commit fixes a `TypeError: __init__() got multiple values for argument 'dimensions'` that occurred when loading a saved agent.

The error was caused by passing the `dimensions` parameter both positionally and as a keyword argument within `**kwargs` to the `SkillManager` constructor during deserialization.

The fix is to explicitly remove the 'dimensions' key from the `kwargs` dictionary before the constructor is called, ensuring the argument is only passed once.