### PR TITLE
Fix(skill_manager): Ensure dimensions are passed during deserialization

### DIFF
--- a/backend/api/services/skill_manager.py
+++ b/backend/api/services/skill_manager.py
@@ -124,9 +124,15 @@ class SkillManager:
         kwargs.pop('dimensions', None)
         manager = cls(dimensions, **kwargs)
 
+        # Ensure the dimensions are passed down to the STAG frameworks.
+        # This is critical for deserializing older save files where individual
+        # STAG structures might not have the 'dimensions' key.
+        downstream_kwargs = kwargs.copy()
+        downstream_kwargs['dimensions'] = dimensions
+
         # Load skill graphs
         for skill_id, stag_data in structure.get('skill_graphs', {}).items():
-            manager.skill_graphs[skill_id] = STAG_Framework.from_serializable_structure(stag_data, **kwargs)
+            manager.skill_graphs[skill_id] = STAG_Framework.from_serializable_structure(stag_data, **downstream_kwargs)
 
         # Load option models
         for skill_id, options_data in structure.get('option_models', {}).items():


### PR DESCRIPTION
When loading a saved agent state, the SkillManager was not correctly propagating the `dimensions` parameter to the STAG_Framework's deserialization method. If a skill's saved data structure was missing the 'dimensions' key (e.g., in older save files), it would be initialized with `dimensions=None`.

This would then cause a `TypeError: 'NoneType' object cannot be interpreted as an integer` in the `GNG_Engine` when it attempted to create initial nodes with `np.random.randn(None)`.

This commit fixes the issue by explicitly adding the `dimensions` to the keyword arguments passed to `STAG_Framework.from_serializable_structure`, ensuring that all child components are created with the correct dimensionality.