### PR TITLE
Fix(deserialization): Handle duplicate 'dimensions' argument

### DIFF
--- a/backend/api/services/stag_framework.py
+++ b/backend/api/services/stag_framework.py
@@ -196,9 +196,22 @@ class STAG_Framework:
         """
         Creates a STAG instance from a serialized structure.
         """
-        stag = cls(structure.get('dimensions', kwargs.get('dimensions')), **kwargs)
+        # Determine dimensions, prioritizing the structure's value but falling back to kwargs.
+        # This is key to supporting older save files where the agent's top-level
+        # dimensions need to be passed down.
+        dimensions = structure.get('dimensions', kwargs.get('dimensions'))
+
+        # Create a clean set of kwargs for initialization, removing 'dimensions'
+        # to prevent a TypeError from passing it both positionally and as a keyword.
+        init_kwargs = kwargs.copy()
+        init_kwargs.pop('dimensions', None)
+
+        stag = cls(dimensions, **init_kwargs)
         stag._next_level_id = structure.get('_next_level_id', 0)
-        stag.tree = stag._deserialize_level(structure['tree'], kwargs)
+
+        # Pass the clean kwargs down to the level deserialization to prevent
+        # the same TypeError in the GNG_Engine constructor.
+        stag.tree = stag._deserialize_level(structure['tree'], init_kwargs)
         return stag
 
     def _deserialize_level(self, level_dict, kwargs):


### PR DESCRIPTION
This commit resolves a `TypeError: __init__() got multiple values for argument 'dimensions'` that occurred during agent state deserialization.

The previous fix ensured that the `dimensions` parameter was always passed down from the `SkillManager` to the `STAG_Framework`. However, this created a new issue when the serialized data for the `STAG_Framework` *also* contained a 'dimensions' key, leading to the argument being passed twice.

This commit corrects the issue in `stag_framework.py` by:
1.  Determining the correct `dimensions` value, prioritizing the value from the serialized structure but falling back to the passed keyword arguments.
2.  Removing the `dimensions` key from the keyword arguments before calling the constructor, thus preventing the `TypeError`.
3.  Passing the cleaned keyword arguments to downstream deserialization methods (`_deserialize_level`) to prevent the same error in the `GNG_Engine` constructor.

This ensures the deserialization process is robust and backward-compatible with different versions of saved state files.