### PR TITLE
Fix: Resolve ValueError from goal shape mismatch in replay buffer.

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -47,11 +47,12 @@ class Command(BaseCommand):
         logger.info(f"Loaded configuration from {config_path}")
 
         agent_config = config.get('agent_config', {})
+        training_config = config.get('training', {})
         hyperparams = agent_config.get('hyperparams', {})
         history_config = config.get('agent_history', {})
 
         # --- Set Seed for Reproducibility ---
-        seed = config.get('training', {}).get('seed')
+        seed = training_config.get('seed')
         if seed is not None:
             logger.info(f"Setting random seed to {seed}")
             seed_all(seed)
@@ -84,12 +85,15 @@ class Command(BaseCommand):
         agent_id = agent_config.get('default_agent_id_prefix', 'Kymera-') + "local-train"
         embedding_dim = agent_config.get('embedding_dim', 512)
 
+        save_weights = training_config.get('save_weights', True)
+
         agent = ChimeraAgent(
             agent_id=agent_id,
             embedding_dim=embedding_dim,
             max_action_dim=max_action_dim,
             cortex_configs=master_cortex_configs,
-            load_from_storage=not config.get('force_new_agent', False),
+            load_from_storage=save_weights,
+            enable_saving=save_weights,
             hyperparams=hyperparams,
             history_config=history_config
         )
@@ -135,10 +139,12 @@ class Command(BaseCommand):
                                len(agent.replay_buffer) > hyperparams.get('batch_size', 16):
                                 train_stats = agent.train(cortex_id)
                                 if train_stats:
-                                    pbar.set_postfix({
-                                        "AC Loss": f"{train_stats.get('ac_loss', 'N/A'):.4f}",
-                                        "WM Loss": f"{train_stats.get('wm_loss_total', 'N/A'):.4f}"
-                                    })
+                                    postfix_stats = {
+                                        "WM Loss": f"{train_stats.get('wm_loss_total', 0):.4f}"
+                                    }
+                                    if 'ac_loss' in train_stats:
+                                        postfix_stats["AC Loss"] = f"{train_stats['ac_loss']:.4f}"
+                                    pbar.set_postfix(postfix_stats)
 
                         logger.info(f"Ep {episode_num} | Reward: {episode_reward:.2f} | Total Steps: {total_steps}")
 
@@ -147,5 +153,8 @@ class Command(BaseCommand):
         except KeyboardInterrupt:
             logger.info("Training interrupted by user.")
         finally:
-            agent.save_state(version_info={"message": "Local training stopped."})
-            logger.info("Training finished and agent state saved.")
+            if save_weights:
+                agent.save_state(version_info={"message": "Local training stopped."})
+                logger.info("Training finished and agent state saved.")
+            else:
+                logger.info("Training finished. Agent state not saved as per config.")

--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -108,8 +108,9 @@ def sanitize_state_dict(state):
     return state
 
 class ChimeraAgent:
-    def __init__(self, agent_id, embedding_dim, max_action_dim, latent_dim=128, hidden_dim=512, cortex_configs=None, load_from_storage=True, hyperparams=None, history_config=None, **kwargs):
+    def __init__(self, agent_id, embedding_dim, max_action_dim, latent_dim=128, hidden_dim=512, cortex_configs=None, load_from_storage=True, enable_saving=True, hyperparams=None, history_config=None, **kwargs):
         self.agent_id = agent_id
+        self.enable_saving = enable_saving
         self.embedding_dim = embedding_dim
         self.max_action_dim = max_action_dim
         self.latent_dim = latent_dim
@@ -279,7 +280,8 @@ class ChimeraAgent:
         if load_from_storage and self.history_manager._read_history():
             self.load_state()
         else:
-            self.save_state(version_info={"message": "Initial state."})
+            if self.enable_saving:
+                self.save_state(version_info={"message": "Initial state."})
 
         buffer_capacity = self.hyperparams.get('buffer_capacity', 10000)
         sequence_length = self.hyperparams.get('sequence_length', 50)
@@ -290,7 +292,8 @@ class ChimeraAgent:
             beta_start=self.hyperparams.get('per_beta_start', 0.4),
             beta_frames=self.hyperparams.get('per_beta_frames', 100000),
             her_replay_strategy=self.her_replay_strategy,
-            her_replay_k=self.her_replay_k
+            her_replay_k=self.her_replay_k,
+            goal_dim=self.goal_dim
         )
 
     def save_state(self, version_info={}):

--- a/backend/api/services/per_sequence_buffer.py
+++ b/backend/api/services/per_sequence_buffer.py
@@ -47,9 +47,10 @@ class SegmentTree:
         return self.tree[0]
 
 class PERSequenceBuffer:
-    def __init__(self, capacity, sequence_length=50, alpha=0.6, beta_start=0.4, beta_frames=100000, her_replay_strategy='future', her_replay_k=4):
+    def __init__(self, capacity, sequence_length=50, alpha=0.6, beta_start=0.4, beta_frames=100000, her_replay_strategy='future', her_replay_k=4, goal_dim=512):
         self.capacity = capacity
         self.sequence_length = sequence_length
+        self.goal_dim = goal_dim
         self.alpha = alpha
         self.beta_start = beta_start
         self.beta_frames = beta_frames
@@ -113,13 +114,23 @@ class PERSequenceBuffer:
             else: # 'final'
                 new_goal = sequence[-1].next_obs
 
+            # AGENT_FIX: Pad the goal if its dimension does not match the required goal_dim.
+            # This handles cases where HER uses environment observations as goals.
+            goal_for_reward = new_goal
+            padded_goal = new_goal
+            if new_goal.shape[0] < self.goal_dim:
+                padded_goal = np.zeros(self.goal_dim)
+                padded_goal[:new_goal.shape[0]] = new_goal
+
+
             # Relabel the sequence with the new goal and recalculate rewards
             new_sequence = []
             for exp in sequence:
                 # The new reward is the negative distance to the new goal
-                # We assume the goal is in the observation space for simplicity
-                new_reward = -np.linalg.norm(exp.obs - new_goal)
-                new_exp = exp._replace(goal=new_goal, reward=new_reward)
+                # We use the un-padded goal for reward calculation.
+                new_reward = -np.linalg.norm(exp.obs - goal_for_reward)
+                # We store the padded goal in the experience.
+                new_exp = exp._replace(goal=padded_goal, reward=new_reward)
                 new_sequence.append(new_exp)
             batch[i] = new_sequence
 

--- a/backend/configs/base.yaml
+++ b/backend/configs/base.yaml
@@ -15,6 +15,9 @@ agent_history:
 # Main training settings
 max_training_steps: 2000000 # The total number of environment steps to train for.
 
+training:
+  save_weights: false # If false, agent state will not be saved to or loaded from storage.
+
 # Agent architecture and hyperparameters
 agent_config:
   embedding_dim: 512 # The fixed-size vector dimension produced by any cortex.


### PR DESCRIPTION
The training process was crashing due to a `ValueError` when stacking experience tuples in the replay buffer. This was caused by the Hindsight Experience Replay (HER) mechanism creating goals from environment observations (e.g., shape `(2,)`) which had a different shape from the agent's default internal goal representation (shape `(512,)`).

This commit resolves the issue by:
1.  Making the `PERSequenceBuffer` aware of the agent's `goal_dim`.
2.  Padding the HER-generated goals with zeros to ensure they have a consistent shape with other goals in the buffer.
3.  Updating the reward calculation to use the original, un-padded goal for distance calculation, while storing the padded goal in the experience.

Additionally, this commit introduces a `save_weights` flag in the configuration to allow for disabling the saving and loading of the agent's state. This is useful for debugging and ensuring a fresh agent state for training runs.