### PR TITLE
Fix: Add backward compatibility and resolve logging error.

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -135,10 +135,12 @@ class Command(BaseCommand):
                                len(agent.replay_buffer) > hyperparams.get('batch_size', 16):
                                 train_stats = agent.train(cortex_id)
                                 if train_stats:
-                                    pbar.set_postfix({
-                                        "AC Loss": f"{train_stats.get('ac_loss', 'N/A'):.4f}",
-                                        "WM Loss": f"{train_stats.get('wm_loss_total', 'N/A'):.4f}"
-                                    })
+                                    postfix_stats = {
+                                        "WM Loss": f"{train_stats.get('wm_loss_total', 0):.4f}"
+                                    }
+                                    if 'ac_loss' in train_stats:
+                                        postfix_stats["AC Loss"] = f"{train_stats['ac_loss']:.4f}"
+                                    pbar.set_postfix(postfix_stats)
 
                         logger.info(f"Ep {episode_num} | Reward: {episode_reward:.2f} | Total Steps: {total_steps}")
 

--- a/backend/api/services/skill_manager.py
+++ b/backend/api/services/skill_manager.py
@@ -135,9 +135,9 @@ class SkillManager:
         for skill_id, stag_data in structure.get('skill_graphs', {}).items():
             stag = STAG_Framework.from_serializable_structure(stag_data, **downstream_kwargs)
             # AGENT_FIX: Add backward compatibility for 'psi' key in GNG nodes
-            if max(stag.level_map.keys()) in stag.level_map:
+            if stag.level_map: # Check if there are any levels
                 terminal_gng = stag.level_map[max(stag.level_map.keys())]
-                for node_id, node_data in terminal_gng['gng'].nodes.items():
+                for node_id, node_data in terminal_gng.nodes.items():
                     if 'psi' not in node_data:
                         node_data['psi'] = np.zeros(sf_dimension)
             manager.skill_graphs[skill_id] = stag


### PR DESCRIPTION
This commit adds two follow-up fixes:
1.  A `TypeError` in the `SkillManager`'s deserialization logic is resolved. The backward-compatibility code for the 'psi' key was making an incorrect assumption about a data structure. This is now corrected.
2.  A `ValueError` in the progress bar display in `train_agent.py` is fixed. The code now conditionally formats the 'AC Loss' statistic, preventing a crash when the value is not present.