### PR TITLE
Feat: Add dev script to run frontend on port 3001.

### DIFF
--- a/frontend/chimera_frontend/package.json
+++ b/frontend/chimera_frontend/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "dev": "PORT=3001 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Adds a new `dev` script to the `package.json` file for the frontend application. Running `npm run dev` will now start the React development server on port 3001, as requested.