### PR TITLE
Fix: Add tsconfig.json and resolve frontend compilation errors.

### DIFF
--- a/frontend/chimera_frontend/tsconfig.json
+++ b/frontend/chimera_frontend/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
This commit addresses a compilation failure that occurred after migrating the frontend to TypeScript.

- A `tsconfig.json` file has been added to the frontend project. This file was missing, which caused the TypeScript compiler to fail when trying to resolve modules.
- The version of the `typescript` dependency has been pinned to `4.9.5` to resolve a peer dependency conflict with `react-scripts`.
- The `recharts` charting library and its type definitions have been added as dependencies.