### PR TITLE
Fix: Resolve compilation error from missing type import.

### DIFF
--- a/frontend/chimera_frontend/src/App.tsx
+++ b/frontend/chimera_frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import NetworkVisualizer from './NetworkVisualizer';
+import NetworkVisualizer, { GraphData } from './NetworkVisualizer';
 import PerformanceChart from './PerformanceChart';
 import './App.css';
 
@@ -8,11 +8,6 @@ import './App.css';
 interface Environment {
   id: string;
   name: string;
-}
-
-interface GraphData {
-  nodes: any[];
-  edges: any[];
 }
 
 interface TrainingMetric {

--- a/frontend/chimera_frontend/src/NetworkVisualizer.tsx
+++ b/frontend/chimera_frontend/src/NetworkVisualizer.tsx
@@ -3,9 +3,13 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls, Text, Bounds, Line } from '@react-three/drei';
 import * as THREE from 'three';
 import { forceSimulation, forceLink, forceManyBody, forceCenter, Simulation, SimulationNodeDatum, SimulationLinkDatum } from 'd3-force';
-import { GraphData } from './api';
 
-// --- Type Definitions for d3-force ---
+// --- Type Definitions ---
+
+export interface GraphData {
+  nodes: any[];
+  edges: any[];
+}
 
 interface NodeDatum extends SimulationNodeDatum {
   id: number;


### PR DESCRIPTION
This commit fixes a `Module not found` error in `NetworkVisualizer.tsx`.

The `GraphData` type was still being imported from the `api.ts` file, which had been deleted in a previous refactoring step.

The fix involves:
- Moving the `GraphData` interface definition into `NetworkVisualizer.tsx`.
- Updating the import statement in `App.tsx` to import `GraphData` from `NetworkVisualizer.tsx`.