### PR TITLE
Fix: Correct real-time streaming architecture.

### DIFF
--- a/backend/chimera_project/settings.py
+++ b/backend/chimera_project/settings.py
@@ -86,8 +86,11 @@ ASGI_APPLICATION = "chimera_project.asgi.application"
 
 CHANNEL_LAYERS = {
     "default": {
-        "BACKEND": "channels.layers.InMemoryChannelLayer"
-    }
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {
+            "hosts": [("127.0.0.1", 6379)],
+        },
+    },
 }
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ openai
 tqdm
 channels
 daphne
+channels_redis

--- a/frontend/chimera_frontend/src/NetworkVisualizer.tsx
+++ b/frontend/chimera_frontend/src/NetworkVisualizer.tsx
@@ -111,8 +111,8 @@ const ForceGraph: React.FC<ForceGraphProps> = ({ graphData }) => {
   const simulationRef = useRef<Simulation<NodeDatum, EdgeDatum> | null>(null);
 
   useEffect(() => {
-    const gngNodes = graphData?.gng_state?.nodes || {};
-    const gngEdges: [number, number][] = graphData?.gng_state?.edges || [];
+    const gngNodes = graphData?.nodes || {};
+    const gngEdges: [number, number][] = graphData?.edges || [];
 
     const nodeArray: NodeDatum[] = Object.entries(gngNodes).map(([id, data]: [string, any]) => {
       // Initialize position from weight vector for stable layout, falling back to random
@@ -173,7 +173,7 @@ const ForceGraph: React.FC<ForceGraphProps> = ({ graphData }) => {
 
 
 const NetworkVisualizer: React.FC<NetworkVisualizerProps> = ({ graphData }) => {
-  if (!graphData || !graphData.gng_state) {
+  if (!graphData || !graphData.nodes) {
     return <div style={{ color: 'white', margin: '20px' }}>Loading graph data or no data available...</div>;
   }
 


### PR DESCRIPTION
This commit fixes two critical bugs that prevented the real-time UI from functioning:

1.  **Backend:** The Django Channels configuration in `settings.py` was using `InMemoryChannelLayer`, which does not support communication between the web server process and the management command process. This has been corrected to use `RedisChannelLayer`, and `channels_redis` has been added as a dependency. This allows the `train_agent` script to correctly broadcast messages to the frontend.

2.  **Frontend:** The `NetworkVisualizer.tsx` component was attempting to access data from a stale key (`gng_state`) within the `graphData` object. This has been corrected to access the `nodes` and `edges` properties directly, aligning the component with the data structure being broadcast by the backend.