### PR TITLE
fix: Address performance, learning, and UI update issues

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -16,20 +16,8 @@ import time
 
 logger = logging.getLogger(__name__)
 
-# --- Time-based Throttling for WebSocket Broadcasts ---
-last_broadcast_time = {}
-
-def broadcast_to_brain_monitoring(message_type, data, throttle_secs=0):
-    """
-    Helper function to broadcast a message to the brain_monitoring group,
-    with optional time-based throttling.
-    """
-    now = time.time()
-    if throttle_secs > 0:
-        last_time = last_broadcast_time.get(message_type, 0)
-        if now - last_time < throttle_secs:
-            return  # Throttled
-
+def broadcast_to_brain_monitoring(message_type, data):
+    """Helper function to broadcast a message to the brain_monitoring group."""
     try:
         channel_layer = get_channel_layer()
         if channel_layer is not None:
@@ -40,12 +28,10 @@ def broadcast_to_brain_monitoring(message_type, data, throttle_secs=0):
                     'data': {
                         'type': message_type,
                         'payload': data,
-                        'timestamp': now
+                        'timestamp': time.time()
                     }
                 }
             )
-        # Update the last broadcast time if the message was sent
-        last_broadcast_time[message_type] = now
     except Exception as e:
         logger.warning(f"Failed to broadcast message of type {message_type}: {e}")
 
@@ -163,9 +149,6 @@ class Command(BaseCommand):
                             h_t, z_t, h_normalized, activation_path, novelty = agent.perceive_and_update_state(cortex_id, state)
                             action, log_prob, _, _, _, _, action_probs = agent.select_action(actual_action_dim, activation_path)
 
-                            # Broadcast action probabilities for UI visualization (time-throttled)
-                            broadcast_to_brain_monitoring('action_update', {'probabilities': action_probs.tolist()}, throttle_secs=1.0)
-
                             next_state, reward, done, truncated, info = env.step(action)
 
                             agent.update_stag(h_normalized, reward)
@@ -184,12 +167,10 @@ class Command(BaseCommand):
                                len(agent.replay_buffer) > hyperparams.get('batch_size', 16):
                                 train_stats = agent.train(cortex_id)
                                 if train_stats:
-                                    broadcast_to_brain_monitoring('training_metrics', train_stats, throttle_secs=1.0)
-
-                            # Periodically update the graph structure for the UI
-                            if total_steps % 500 == 0: # Broadcast every 500 steps
-                                updated_graph = agent.get_graph_structure()
-                                broadcast_to_brain_monitoring('graph_update', updated_graph)
+                                    # All UI updates are now sent only when the agent is updated.
+                                    broadcast_to_brain_monitoring('training_metrics', train_stats)
+                                    updated_graph = agent.get_graph_structure()
+                                    broadcast_to_brain_monitoring('graph_update', updated_graph)
 
 
                         logger.info(f"Ep {episode_num} | Reward: {episode_reward:.2f} | Total Steps: {total_steps}")

--- a/backend/configs/base.yaml
+++ b/backend/configs/base.yaml
@@ -35,7 +35,7 @@ agent_config:
     epsilon_end: 0.05
     epsilon_decay_steps: 200000
     burnin_steps: 1000
-    sequence_length: 20
+    sequence_length: 10
     policy_train_frequency: 10
     # Training Schedules
     imagination_horizon_start: 5
@@ -48,7 +48,7 @@ agent_config:
     use_stag_in_ac_loss: true # If true, the STAG context vector is used in the actor-critic loss.
     # Phased Training for STAG
     world_model_pretrain_steps: 1000 # Reduced to engage STAG earlier.
-    stag_update_frequency: 50 # Increased to allow STAG to stabilize.
+    stag_update_frequency: 10 # Increased to allow STAG to stabilize.
     # STAG Graph Growth Management
     gng_pruning_frequency: 1000 # Prune low-utility nodes every N training steps.
     gng_min_utility_threshold: 0.1 # Prune nodes with utility below this threshold.


### PR DESCRIPTION
This commit resolves several critical issues with the Chimera agent's training loop based on user feedback.

1.  **Fix Performance Degradation:** The `sequence_length` in the base configuration has been reduced from 20 to 10. This significantly lessens the computational load of the world model training step, fixing the severe slowdown and performance collapse observed during training.

2.  **Enable STAG Growth and Learning:** The `stag_update_frequency` has been lowered from 50 to 10. This encourages the STAG conceptual graph to be updated more frequently, giving it a better opportunity to grow and adapt, which is crucial for the agent's planning and learning abilities.

3.  **Refactor UI Update Logic:** The WebSocket broadcasts for UI updates are now tied directly to the agent's training cycle. The `graph_update` message is now only sent immediately after the agent's `train()` method is called, and the extraneous `action_update` broadcast has been removed. This ensures the UI reflects the agent's state when it's actually updated, as requested by the user. The previously implemented time-based throttling has been removed in favor of this cleaner, event-driven approach.