### PR TITLE
refactor: Finalize Colosseum training and Redis UI updates

### DIFF
--- a/backend/api/consumers.py
+++ b/backend/api/consumers.py
@@ -1,47 +1,81 @@
 import json
 import logging
+import asyncio
+import redis.asyncio as aioredis
 from channels.generic.websocket import AsyncWebsocketConsumer
 
 logger = logging.getLogger(__name__)
 
 class BrainConsumer(AsyncWebsocketConsumer):
     """
-    This consumer handles WebSocket connections for broadcasting
-    real-time training metrics and other agent-related events.
+    This consumer handles WebSocket connections for providing real-time
+    agent state by polling a Redis cache.
     """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.redis = None
+        self.poll_task = None
+        self.connected = False
+        self.last_known_states = {}
+        # Map Redis keys to the message types the frontend expects
+        self.key_to_message_type = {
+            "chimera_environments": "environments_update",
+            "chimera_graph_state": "graph_update",
+            "chimera_training_metrics": "training_metrics",
+            "chimera_episode_metrics": "training_metrics", # Both use the same handler
+            "chimera_action_update": "action_update"
+        }
+        self.redis_keys_to_poll = list(self.key_to_message_type.keys())
+
     async def connect(self):
-        """
-        Called when the websocket is trying to connect.
-        """
-        self.room_group_name = 'brain_monitoring'
-
-        # Join room group
-        await self.channel_layer.group_add(
-            self.room_group_name,
-            self.channel_name
-        )
-
+        """Called when the websocket is trying to connect."""
         await self.accept()
-        logger.info(f"BrainConsumer connected to group '{self.room_group_name}'")
+        logger.info("BrainConsumer connected.")
+        self.connected = True
+        try:
+            self.redis = aioredis.StrictRedis(host='localhost', port=6379, db=0, decode_responses=True)
+            await self.redis.ping()
+            logger.info("Consumer successfully connected to Redis.")
+            # Start the polling task
+            self.poll_task = asyncio.create_task(self.poll_redis_for_updates())
+        except Exception as e:
+            logger.error(f"Consumer could not connect to Redis: {e}. Closing connection.")
+            await self.close()
 
     async def disconnect(self, close_code):
-        """
-        Called when the WebSocket closes for any reason.
-        """
+        """Called when the WebSocket closes."""
         logger.info(f"BrainConsumer disconnecting with code: {close_code}")
-        # Leave room group
-        await self.channel_layer.group_discard(
-            self.room_group_name,
-            self.channel_name
-        )
+        self.connected = False
+        if self.poll_task:
+            self.poll_task.cancel()
+        if self.redis:
+            await self.redis.close()
 
-    async def training_update(self, event):
-        """
-        Handler for messages sent to the 'brain_monitoring' group.
-        It forwards the message directly to the WebSocket client.
-        """
-        message_data = event.get('data', {})
+    async def poll_redis_for_updates(self):
+        """Periodically polls Redis for changes and sends updates to the client."""
+        while self.connected:
+            try:
+                for key in self.redis_keys_to_poll:
+                    current_state_json = await self.redis.get(key)
+                    if current_state_json:
+                        # Check if the state has changed since the last time we sent it
+                        if self.last_known_states.get(key) != current_state_json:
+                            self.last_known_states[key] = current_state_json
+                            # Use the mapping to get the correct message type
+                            message_type = self.key_to_message_type.get(key)
+                            if message_type:
+                                message = {
+                                    "type": message_type,
+                                    "payload": json.loads(current_state_json)
+                                }
+                                await self.send(text_data=json.dumps(message))
 
-        # Send message to WebSocket
-        await self.send(text_data=json.dumps(message_data))
-        logger.debug(f"Sent training_update to client: {message_data}")
+                # Wait for the next poll interval
+                await asyncio.sleep(1.0)
+            except asyncio.CancelledError:
+                logger.info("Redis polling task cancelled.")
+                break
+            except Exception as e:
+                logger.error(f"Error during Redis polling: {e}")
+                # Wait before retrying to avoid spamming errors
+                await asyncio.sleep(5.0)

--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -1,194 +1,216 @@
-# Forcing re-compile to address caching issues.
-import numpy as np
-import os
-import torch
-import yaml
+import asyncio
 import logging
+import yaml
+import numpy as np
+import torch
+import websockets
 import random
 from tqdm import tqdm
+
 from django.core.management.base import BaseCommand
 from api.services.chimera_agent import ChimeraAgent
+from colosseum_connector import ColosseumConnector
 from api.services.cortex.factory import create_cortex_configs_from_observation_space
 import gymnasium as gym
-from channels.layers import get_channel_layer
-from asgiref.sync import async_to_sync
+import redis
+import json
 import time
 
+# --- Setup logging ---
 logger = logging.getLogger(__name__)
 
-def broadcast_to_brain_monitoring(message_type, data):
-    """Helper function to broadcast a message to the brain_monitoring group."""
-    try:
-        channel_layer = get_channel_layer()
-        if channel_layer is not None:
-            async_to_sync(channel_layer.group_send)(
-                'brain_monitoring',
-                {
-                    'type': 'training_update', # This is the handler method name in the consumer
-                    'data': {
-                        'type': message_type,
-                        'payload': data,
-                        'timestamp': time.time()
-                    }
-                }
-            )
-    except Exception as e:
-        logger.warning(f"Failed to broadcast message of type {message_type}: {e}")
+# --- Redis Caching for UI ---
+try:
+    redis_client = redis.StrictRedis(host='localhost', port=6379, db=0, decode_responses=True)
+    redis_client.ping()
+    logger.info("Successfully connected to Redis for UI state caching.")
+except redis.exceptions.ConnectionError as e:
+    logger.error(f"Could not connect to Redis: {e}. UI updates will be disabled.")
+    redis_client = None
 
-def seed_all(s):
-    """Sets the seed for all random number generators."""
-    random.seed(s)
-    np.random.seed(s)
-    torch.manual_seed(s)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(s)
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False
+def update_ui_state_in_redis(key, data):
+    """Serializes data to JSON and stores it in a Redis key."""
+    if redis_client is None:
+        return
+    try:
+        payload = json.dumps(data, cls=NumpyJSONEncoder)
+        redis_client.set(key, payload)
+    except Exception as e:
+        logger.warning(f"Failed to update UI state in Redis for key {key}: {e}")
+
+class NumpyJSONEncoder(json.JSONEncoder):
+    """ Custom encoder for numpy data types """
+    def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        return json.JSONEncoder.default(self, obj)
 
 class Command(BaseCommand):
-    help = 'Train a ChimeraAgent using local Gymnasium environments.'
+    help = 'Train a ChimeraAgent using a Colosseum server environment.'
 
     def add_arguments(self, parser):
-        parser.add_argument("--config", type=str, default="configs/base.yaml", help="Path to the main configuration file.")
-        parser.add_argument("--env-curriculum", type=str, default="MountainCar-v0", help="A single env name or a comma-separated list of env names for curriculum learning.")
-        parser.add_argument("--total-steps", type=int, default=50000, help="Total number of steps to train for across all environments.")
-        parser.add_argument("--steps-per-env", type=int, default=50000, help="Number of steps to train on each environment in the curriculum.")
+        parser.add_argument("--config", type=str, default="backend/configs/base.yaml", help="Path to the main configuration file.")
+        parser.add_argument("--env-id", type=str, default="LunarLander-v2", help="The Colosseum environment ID to train in.")
+        parser.add_argument("--episodes", type=int, default=500, help="Total number of episodes to train for.")
+        parser.add_argument("--agent-tag", type=str, default=None, help="A unique tag for the agent.")
+        parser.add_argument("--port", type=int, default=8002, help="The port of the Colosseum server.")
 
     def handle(self, *args, **options):
+        """Synchronous entry point that runs the async handler."""
+        try:
+            asyncio.run(self.async_handle(*args, **options))
+        except KeyboardInterrupt:
+            logger.info("Training interrupted by user.")
+        except Exception as e:
+            logger.error(f"An unexpected error occurred in async_handle: {e}", exc_info=True)
+
+    async def async_handle(self, *args, **options):
+        """The main asynchronous logic for training the agent."""
         logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
+        env_id = options['env_id']
+        agent_tag = options['agent_tag'] or f"chimera-agent-{random.randint(1000, 9999)}"
+        config_path = options['config']
+        episodes = options['episodes']
+        port = options['port']
+
+        logger.info(f"Starting Chimera agent '{agent_tag}' for environment: {env_id} on port {port}")
+
         # --- Load Configuration ---
-        config_path = os.path.join('', options['config'])
         try:
             with open(config_path, 'r') as f:
                 config = yaml.safe_load(f)
+            logger.info(f"Loaded configuration from {config_path}")
         except FileNotFoundError:
             logger.error(f"Config file not found at: {config_path}")
             return
-
-        logger.info(f"Loaded configuration from {config_path}")
 
         agent_config = config.get('agent_config', {})
         hyperparams = agent_config.get('hyperparams', {})
         history_config = config.get('agent_history', {})
 
-        # --- Set Seed for Reproducibility ---
-        seed = config.get('training', {}).get('seed')
-        if seed is not None:
-            logger.info(f"Setting random seed to {seed}")
-            seed_all(seed)
+        # --- Colosseum Connection ---
+        connector = ColosseumConnector(env_id, agent_tag, port=port)
 
-        # --- Environment & Agent Setup ---
-        env_names = [env.strip() for env in options['env_curriculum'].split(',')]
-        total_training_steps = options['total_steps']
-        steps_per_env = options['steps_per_env']
-
-        # --- Pre-inspect all environments locally ---
-        master_cortex_configs = {}
-        max_action_dim = 0
-        for name in env_names:
-            logger.info(f"Inspecting local environment: {name}")
-            try:
-                temp_env = gym.make(name)
-                env_cortex_configs, _ = create_cortex_configs_from_observation_space(temp_env.observation_space)
-                master_cortex_configs.update(env_cortex_configs)
-                if isinstance(temp_env.action_space, gym.spaces.Discrete):
-                    max_action_dim = max(max_action_dim, temp_env.action_space.n)
-                temp_env.close()
-            except Exception as e:
-                logger.error(f"Could not inspect environment {name}: {e}. Skipping.")
-                env_names.remove(name)
-
-        logger.info(f"Master cortex configuration will include: {list(master_cortex_configs.keys())}")
-        logger.info(f"Max action dimension across all environments: {max_action_dim}")
-
-        # Broadcast environment list to the UI
-        env_list_for_ui = [{'id': name, 'name': name} for name in env_names]
-        broadcast_to_brain_monitoring('environments_update', env_list_for_ui)
-
-        # --- Initialize a single, generalist agent ---
-        agent_id = agent_config.get('default_agent_id_prefix', 'Kymera-') + "local-train"
-        embedding_dim = agent_config.get('embedding_dim', 512)
-
-        agent = ChimeraAgent(
-            agent_id=agent_id,
-            embedding_dim=embedding_dim,
-            max_action_dim=max_action_dim,
-            cortex_configs=master_cortex_configs,
-            load_from_storage=not config.get('force_new_agent', False),
-            hyperparams=hyperparams,
-            history_config=history_config
-        )
-        logger.info(f"Initialized Generalist Agent '{agent_id}'")
-
-        # Broadcast initial graph structure
-        initial_graph = agent.get_graph_structure()
-        broadcast_to_brain_monitoring('graph_update', initial_graph)
-
-
-        # --- Training Loop ---
-        total_steps = 0
-        episode_num = 0
         try:
-            for env_id in env_names:
-                logger.info(f"--- Starting Curriculum Stage: {env_id} ---")
-                agent.set_active_skill(env_id)
-                env = gym.make(env_id)
-                _, cortex_id = create_cortex_configs_from_observation_space(env.observation_space)
-                actual_action_dim = env.action_space.n
+            session_info = await connector.create_session()
+            if not session_info:
+                logger.error("Could not create session. Exiting.")
+                return
 
-                steps_in_current_env = 0
-                with tqdm(total=steps_per_env, desc=f"Training on {env_id}") as pbar:
-                    while steps_in_current_env < steps_per_env and total_steps < total_training_steps:
-                        state, _ = env.reset()
-                        done, truncated = False, False
-                        episode_reward = 0
-                        episode_num += 1
+            if not await connector.connect_websocket():
+                logger.error("Could not connect to WebSocket. Exiting.")
+                return
 
-                        while not (done or truncated):
-                            h_t, z_t, h_normalized, activation_path, novelty = agent.perceive_and_update_state(cortex_id, state)
-                            action, log_prob, _, _, _, _, action_probs = agent.select_action(actual_action_dim, activation_path)
+            join_response = await connector.join_session()
+            if not join_response:
+                logger.error("Could not join session. Exiting.")
+                await connector.close()
+                return
 
-                            # Broadcast action probabilities for UI visualization
-                            broadcast_to_brain_monitoring('action_update', {'probabilities': action_probs.tolist()})
+            # --- Environment and Agent Setup (Post-Connection) ---
+            env_specs = join_response['environment']
+            obs_space_info = env_specs['observation_space']
+            action_space_info = env_specs['action_space']
 
-                            next_state, reward, done, truncated, info = env.step(action)
+            observation_space = gym.spaces.Box(
+                low=np.array(obs_space_info['low']),
+                high=np.array(obs_space_info['high']),
+                shape=obs_space_info['shape'],
+                dtype=np.dtype(obs_space_info['dtype'])
+            )
+            cortex_configs, cortex_id = create_cortex_configs_from_observation_space(observation_space)
+            actual_action_dim = action_space_info['n']
 
-                            agent.update_stag(h_normalized, reward)
-                            agent.record_experience(h_t, z_t, activation_path, state, action, log_prob, reward, next_state, done or truncated)
+            agent = ChimeraAgent(
+                agent_id=agent_tag,
+                embedding_dim=agent_config.get('embedding_dim', 512),
+                max_action_dim=actual_action_dim,
+                cortex_configs=cortex_configs,
+                load_from_storage=not config.get('force_new_agent', False),
+                hyperparams=hyperparams,
+                history_config=history_config
+            )
+            agent.set_active_skill(env_id, actual_action_dim)
+            logger.info(f"Initialized Chimera Agent '{agent_tag}' for {env_id}")
 
-                            state = next_state
+            # --- Main Training Loop ---
+            postfix_data = {
+                "Reward": "N/A", "Epsilon": "N/A", "Decision": "N/A",
+                "WM Loss": "N/A", "AC Loss": "N/A", "Nodes": 0, "Edges": 0
+            }
+            with tqdm(total=episodes, desc=f"Training on {env_id}") as pbar:
+                for episode in range(1, episodes + 1):
+                    current_obs = np.array(join_response.get("observation"))
+                    done = False
+                    episode_reward = 0
+                    pbar.set_postfix(postfix_data)
+
+                    while not done:
+                        h_t, z_t, h_normalized, activation_path, novelty = agent.perceive_and_update_state(cortex_id, current_obs)
+                        action, log_prob, _, decision_maker, epsilon, _, action_probs = agent.select_action(actual_action_dim, activation_path)
+
+                        postfix_data["Epsilon"] = f"{epsilon:.2f}"
+                        postfix_data["Decision"] = decision_maker
+                        update_ui_state_in_redis('chimera_action_update', {'probabilities': action_probs})
+
+                        await connector.send_action(int(action))
+                        msg = await connector.receive_message()
+
+                        if not msg:
+                            logger.warning("Did not receive state, might be reconnecting. Ending episode.")
+                            break
+
+                        if msg.get("type") == "action.taken":
+                            next_obs = np.array(msg.get("observation"))
+                            reward = msg.get("reward", 0)
+                            done = msg.get("done", False)
                             episode_reward += reward
-                            total_steps += 1
-                            steps_in_current_env += 1
-                            pbar.update(1)
 
-                            # Online Training
-                            policy_train_frequency = hyperparams.get('policy_train_frequency', 10)
-                            if total_steps > hyperparams.get('burnin_steps', 1000) and \
-                               total_steps % policy_train_frequency == 0 and \
+                            agent.record_experience(h_t, z_t, activation_path, current_obs, action, log_prob, reward, next_obs, done)
+                            current_obs = next_obs
+
+                            if agent.steps_done > hyperparams.get('burnin_steps', 1000) and \
+                               agent.steps_done % hyperparams.get('policy_train_frequency', 10) == 0 and \
                                len(agent.replay_buffer) > hyperparams.get('batch_size', 16):
-                                train_stats = agent.train(cortex_id)
+                                train_stats = agent.train(cortex_id=cortex_id)
                                 if train_stats:
-                                    broadcast_to_brain_monitoring('training_metrics', train_stats)
+                                    wm_loss = train_stats.get('wm_loss_total')
+                                    ac_loss = train_stats.get('ac_loss')
+                                    postfix_data["WM Loss"] = f"{wm_loss:.4f}" if isinstance(wm_loss, (int, float)) else "N/A"
+                                    postfix_data["AC Loss"] = f"{ac_loss:.4f}" if isinstance(ac_loss, (int, float)) else "N/A"
+                                    update_ui_state_in_redis('chimera_training_metrics', train_stats)
 
-                            # Periodically update the graph structure for the UI
-                            if total_steps % 500 == 0: # Broadcast every 500 steps
-                                updated_graph = agent.get_graph_structure()
-                                broadcast_to_brain_monitoring('graph_update', updated_graph)
+                                    updated_graph = agent.get_graph_structure()
+                                    postfix_data["Nodes"] = len(updated_graph.get('nodes', []))
+                                    postfix_data["Edges"] = len(updated_graph.get('edges', []))
+                                    update_ui_state_in_redis('chimera_graph_state', updated_graph)
 
+                        elif msg.get("type") == "game.over":
+                            done = True
+                        else:
+                            logger.warning(f"Unexpected message type received: {msg.get('type')}")
 
-                        logger.info(f"Ep {episode_num} | Reward: {episode_reward:.2f} | Total Steps: {total_steps}")
-                        broadcast_to_brain_monitoring('training_metrics', {
-                            'episode': episode_num,
-                            'reward': episode_reward,
-                            'total_steps': total_steps
-                        })
+                        pbar.set_postfix(postfix_data)
 
-                env.close()
+                    # --- End of Episode ---
+                    postfix_data["Reward"] = f"{episode_reward:.2f}"
+                    pbar.set_postfix(postfix_data)
+                    pbar.update(1)
 
-        except KeyboardInterrupt:
-            logger.info("Training interrupted by user.")
+                    episode_stats = { 'episode': episode, 'reward': episode_reward, 'total_steps': agent.steps_done }
+                    update_ui_state_in_redis('chimera_episode_metrics', episode_stats)
+
+                    if episode < episodes:
+                        reset_response = await connector.reset_environment()
+                        if reset_response:
+                            join_response = reset_response
+                        else:
+                            logger.error("Failed to reset environment. Exiting.")
+                            break
+
         finally:
-            agent.save_state(version_info={"message": "Local training stopped."})
-            logger.info("Training finished and agent state saved.")
+            logger.info("Closing connection and saving agent state.")
+            await connector.close()
+            if 'agent' in locals():
+                agent.save_state(version_info={"message": f"Colosseum training on {env_id} stopped."})


### PR DESCRIPTION
This commit provides a definitive fix for the training and UI update architecture, ensuring the application runs against the Colosseum server and that UI updates are stable.

The key changes are:
1.  **Set `train_agent` for Colosseum:** The `train_agent` Django management command is now the single, correct entry point for training. It has been refactored to exclusively use the `ColosseumConnector` and `asyncio` to connect to and run on a remote Colosseum server. The port now correctly defaults to 8002. All local `gym` logic has been removed.

2.  **Set `consumers.py` for Redis Polling:** The `consumers.py` file has been updated to the version that uses a robust Redis-polling mechanism. This completely decouples the training loop from UI updates and permanently resolves the "channels over capacity" errors.

3.  **Cleanup:** The redundant `run_colosseum_agents.py` script has been removed to avoid confusion.

This commit overwrites the key files to ensure the correct logic is in place, resolving persistent issues where old code was being executed.