### PR TITLE
Fix TypeError in train_agent command

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -121,7 +121,7 @@ class Command(BaseCommand):
                 hyperparams=hyperparams,
                 history_config=history_config
             )
-            agent.set_active_skill(env_id, actual_action_dim)
+            agent.set_active_skill(env_id)
             logger.info(f"Initialized Chimera Agent '{agent_tag}' for {env_id}")
 
             # --- Connect and Join Session ---


### PR DESCRIPTION
The `set_active_skill` method of the `ChimeraAgent` class was being called with an extra argument, `actual_action_dim`, causing a `TypeError`.

The `actual_action_dim` is already passed to the agent's constructor and is not needed by `set_active_skill`. This commit removes the extraneous argument from the method call.