### PR TITLE
This commit addresses two separate issues in the agent training process.

### DIFF
--- a/backend/colosseum_connector.py
+++ b/backend/colosseum_connector.py
@@ -223,8 +223,20 @@ class ColosseumConnector:
                 logger.error("Cannot receive message, reconnection failed.")
                 return None
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse JSON from message: {e}")
-            return None
+            logger.warning(f"Failed to parse JSON from message: {e}. Attempting to re-parse for double-encoding.")
+            try:
+                # This handles cases where the message is a JSON string that itself contains a JSON string,
+                # e.g., '"{\\"type\\": \\"game.over\\"}"'
+                unwrapped_message = json.loads(message)
+                if isinstance(unwrapped_message, str):
+                    return json.loads(unwrapped_message)
+                else:
+                    # If the unwrapped message isn't a string, we can't parse it further.
+                    logger.error("Message unwrapped to a non-string type, cannot re-parse.")
+                    return None
+            except Exception as inner_e:
+                logger.error(f"Failed to re-parse double-encoded message: {inner_e}")
+                return None
 
     async def reconnect(self, max_retries=3, delay=1):
         """


### PR DESCRIPTION
1. Fix TypeError in train_agent command: The `set_active_skill` method of the `ChimeraAgent` class was being called with an extra argument, `actual_action_dim`, causing a `TypeError`. The extra argument has been removed.

2. Fix client disconnection after episodes: The training client was disconnecting after each episode. This was caused by the client's WebSocket handler crashing when it received a double-encoded JSON message from the server at the end of an episode. The `colosseum_connector` has been made more robust to handle this malformed message, preventing the crash and allowing training to continue across multiple episodes.