### PR TITLE
This commit addresses multiple issues to improve agent training stabi…

### DIFF
--- a/backend/colosseum_connector.py
+++ b/backend/colosseum_connector.py
@@ -78,7 +78,7 @@ class ColosseumConnector:
 
     async def send_message(self, message):
         """Sends a raw JSON message to the server, with reconnection logic."""
-        if not self.websocket or self.websocket.closed:
+        if not self.websocket or not self.websocket.open:
             logger.warning(f"WebSocket closed or not available when trying to send {message.get('type')}. Reconnecting.")
             if not await self.reconnect():
                 logger.error(f"Cannot send message of type {message.get('type')}, reconnection failed.")


### PR DESCRIPTION
…lity.

1. Fix TypeError in train_agent command: The `set_active_skill` method was being called with an extra argument, causing a `TypeError`. The extra argument has been removed.

2. Improve client-side connection handling: The training client was getting stuck or disconnecting between episodes. To address this, the `colosseum_connector` has been made more robust:
- A receive timeout has been added to prevent the client from hanging indefinitely if the server stops responding.
- Reconnection logic has been added to the generic `send_message` function, making the `reset_environment` call more resilient to network issues.
- The message receiver now attempts to handle double-encoded JSON messages that were causing the client to crash.