### PR TITLE
This commit addresses multiple issues to improve agent training stabi…

### DIFF
--- a/backend/colosseum_connector.py
+++ b/backend/colosseum_connector.py
@@ -21,18 +21,14 @@ class ColosseumConnector:
         self.keep_alive_task = None
 
     async def _keep_alive(self):
-        """Sends a ping message every 20 seconds to keep the connection alive."""
+        """Sends an application-level ping message every 20 seconds to keep the connection alive."""
         while True:
             try:
                 await asyncio.sleep(20)
                 if self.websocket:
-                    # Rely on exception handling rather than a proactive check like .open or .closed
-                    try:
-                        await self.websocket.ping()
-                        logger.debug("Sent WebSocket ping")
-                    except websockets.exceptions.ConnectionClosed:
-                        logger.warning("Keep-alive ping failed: connection is closed. Exiting keep-alive task.")
-                        break  # Exit the keep-alive loop
+                    # Send a data message instead of a low-level ping frame for compatibility.
+                    await self.send_message({"type": "ping"})
+                    logger.debug("Sent application-level keep-alive ping.")
             except asyncio.CancelledError:
                 logger.info("Keep-alive task cancelled.")
                 break


### PR DESCRIPTION
…lity.

1. Fix TypeError in train_agent command: The `set_active_skill` method was being called with an extra argument, causing a `TypeError`. The extra argument has been removed.

2. Run blocking training call in a separate thread: The synchronous `agent.train()` call was blocking the asyncio event loop, causing the WebSocket connection to time out and drop. The call is now wrapped in `asyncio.to_thread` to run in a separate thread, preventing the event loop from being starved and keeping the connection alive.

3. Implement WebSocket keep-alive mechanism: A background task is now started that sends an application-level ping message (`{"type": "ping"}`) every 20 seconds. This keeps the connection alive and is more compatible than low-level ping frames. The task is managed correctly, starting on connection and stopping on close.

4. Improve client-side connection handling: To make the client more resilient to network issues, the `colosseum_connector` has been made more robust:
- Adds detailed logging for WebSocket disconnection events.
- Adds a receive timeout to prevent the client from hanging.
- Adds reconnection logic to the generic `send_message` function.
- Corrects `AttributeError`s when checking the connection status by using robust exception handling.