### PR TITLE
fix: Use top-level hidden state for LayerNorm in select_action

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -591,7 +591,8 @@ class ChimeraAgent:
         else:
             # Fallback to learned policy
             with torch.no_grad():
-                h_normalized = self.h_norm(self.hidden_state)
+                # Use the top-level hidden state for the policy
+                h_normalized = self.h_norm(self.hidden_state[0])
                 stag_context_vector = self._prepare_stag_context(activation_path)
                 combined_input = torch.cat((h_normalized, stag_context_vector), dim=1)
 


### PR DESCRIPTION
This commit resolves a `TypeError` that occurred in the `select_action` method after the agent's state was changed to be a list of tensors for the `HierarchicalRSSM`.

The `LayerNorm` module (`self.h_norm`) was being called with the entire list of hidden states, when it expects a single tensor as input.

The fix is to explicitly use the top-level hidden state (`self.hidden_state[0]`) for the layer normalization, which is consistent with the logic used elsewhere for STAG updates.