### PR TITLE
fix: Make agent history persistent by using env_id in name

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -121,7 +121,8 @@ class Command(BaseCommand):
 
     async def _setup_components(self, options):
         env_id = options['env_id']
-        agent_tag = options['agent_tag'] or f"chimera-agent-{int(time.time())}"
+        # AGENT_FIX: Use the env_id to create a persistent agent name, allowing history to be loaded.
+        agent_tag = options['agent_tag'] or f"chimera-agent-{env_id}"
         config_path = options['config']
         port = options['port']
 


### PR DESCRIPTION
Previously, the default agent name was generated using a random timestamp, e.g., `chimera-agent-1756493056`. This caused a new agent history to be created for every training run, preventing the agent from loading its progress for a given environment.

This commit changes the default naming convention to be based on the environment ID, e.g., `chimera-agent-LunarLander-v3`.

This ensures that training an agent in the same environment will now load the existing history, allowing the agent to build on its learned skills over time, as intended by the user. The user can still override this with the `--agent-tag` command-line argument.