### PR TITLE
feat: Refactor train_agent to a full actor-learner architecture

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -204,15 +204,19 @@ class Command(BaseCommand):
             **common_params
         )
 
+        # Create a new hyperparams dict for the actor with planning enabled
         actor_hyperparams = hyperparams.copy()
         actor_hyperparams['use_planner'] = True
 
         actor_agent = ChimeraAgent(
             agent_id=f"{agent_tag}-actor",
+            embedding_dim=config.get('agent_config', {}).get('embedding_dim', 512),
+            max_action_dim=action_space_info['n'],
+            cortex_configs=cortex_configs,
+            hyperparams=actor_hyperparams,
+            replay_buffer=replay_buffer,
             load_from_storage=False,
-            history_config={},
-            **common_params,
-            hyperparams=actor_hyperparams
+            history_config={}
         )
         actor_agent.load_state_dict(learner_agent.state_dict())
 


### PR DESCRIPTION
This commit refactors the `train_agent` management command to support a robust, multi-threaded actor-learner setup, addressing several user requests for enhanced functionality and bug fixes.

Key changes include:

1.  **Actor-Learner Separation:**
    - The command now creates two `ChimeraAgent` instances: a learner that runs in a background thread and an actor that runs in the main async loop.
    - The learner continuously trains on experiences from a shared replay buffer and periodically publishes its updated model weights.
    - The actor explores the environment, populates the replay buffer, and pulls the latest weights from the learner.

2.  **Separate Logging:**
    - A new logging setup creates distinct log files for the actor and learner (`{env_id}_actor.log` and `{env_id}_learner.log`), making it easier to debug each process independently.

3.  **Actor Enhancements:**
    - The actor is now configured with `use_planner=True` to enable latent-space planning.
    - The actor's log output now includes the epsilon value and the decision source (e.g., 'planner', 'policy', 'random') for each action taken.

4.  **UI STAG Visualization Fix:**
    - The responsibility for publishing the STAG graph to Redis for the UI is now solely with the learner thread.
    - This centralizes the logic, fixes a race condition where the actor and learner would overwrite the same Redis key, and ensures the UI displays a stable, growing graph from the authoritative agent state.