### PR TITLE
Fix pickling error for Experience class

### DIFF
--- a/backend/api/management/commands/launch_agent.py
+++ b/backend/api/management/commands/launch_agent.py
@@ -11,6 +11,7 @@ from collections import namedtuple
 from django.core.management.base import BaseCommand
 from api.services.chimera_agent import ChimeraAgent
 from api.services.redis_buffer import RedisBuffer
+from api.services.experience import Experience
 from colosseum_connector import ColosseumConnector
 from api.services.cortex.factory import create_cortex_configs_from_observation_space
 import gymnasium as gym
@@ -85,7 +86,6 @@ class Command(BaseCommand):
         )
 
         redis_buffer = RedisBuffer()
-        Experience = namedtuple('Experience', ['h_t', 'z_t', 'activation_path', 'obs', 'action', 'log_prob', 'reward', 'next_obs', 'done', 'goal'])
 
         actor_agent = ChimeraAgent(
             agent_id=agent_tag,

--- a/backend/api/services/experience.py
+++ b/backend/api/services/experience.py
@@ -1,0 +1,3 @@
+from collections import namedtuple
+
+Experience = namedtuple('Experience', ['h_t', 'z_t', 'activation_path', 'obs', 'action', 'log_prob', 'reward', 'next_obs', 'done', 'goal'])


### PR DESCRIPTION
The `Experience` named tuple was defined inside a method, which prevented it from being pickled and sent to Redis.

This change moves the `Experience` definition to a separate file, `api/services/experience.py`, so that it can be imported and used by other modules. This makes the `Experience` class pickleable and resolves the error.