### PR TITLE
Fix: Handle 'game.over' message in Colosseum actor

### DIFF
--- a/backend/api/management/commands/launch_agent.py
+++ b/backend/api/management/commands/launch_agent.py
@@ -175,6 +175,13 @@ class Command(BaseCommand):
                         episode_reward += reward
                         current_obs = next_obs
                     elif msg.get("type") == "game.over":
+                        next_obs = np.array(msg.get("observation", current_obs))
+                        reward = msg.get("reward", 0)
+
+                        experience = Experience(h_t, z_t, activation_path, current_obs, action, log_prob, reward, next_obs, True, actor_agent.current_goal)
+                        redis_buffer.push(experience)
+
+                        episode_reward += reward
                         done = True
 
                 logger.info(f"Episode {episode_count} finished. Reward: {episode_reward:.2f}")


### PR DESCRIPTION
The actor was not correctly handling the 'game.over' message from the Col- osseum environment. When the game ended, the actor would not record the fi- nal experience, leading to the agent not learning from terminal states.

This commit fixes the issue by adding logic to the actor to handle the 'game.over' message. When this message is received, the actor now records the final experience, including the last observation, action, and reward, before ending the episode. This ensures that the agent learns from termi- nal states, which is crucial for effective training.