### PR TITLE
Perf: Reduce CEM planner complexity to speed up training

### DIFF
--- a/backend/configs/base.yaml
+++ b/backend/configs/base.yaml
@@ -65,9 +65,9 @@ agent_config:
     free_bits: 1.0 # KL balancing parameter
     # Latent Planner (CEM)
     cem_plan_horizon: 12
-    cem_num_samples: 1000 # Restored to normal value for better planning
-    cem_top_k: 100      # Restored to normal value for better planning
-    cem_iterations: 10   # Restored to normal value for better planning
+    cem_num_samples: 500
+    cem_top_k: 50
+    cem_iterations: 5
     low_level_plan_frequency: 10 # Plan every 10 steps
     use_planner: true
     high_level_replan_frequency: 100 # Replans every 100 steps


### PR DESCRIPTION
The Cross-Entropy Method (CEM) planner was identified as a significant bottleneck, causing very long training times per step. This commit re- duces the complexity of the planner by tuning its hyperparameters in `base.yaml`.

- `cem_num_samples` has been reduced from 1000 to 500.
- `cem_iterations` has been reduced from 10 to 5.
- `cem_top_k` has been reduced from 100 to 50.

These changes will significantly speed up the planning phase of each training step, allowing for faster iteration and learning, with a potential minor trade-off in plan quality.