### PR TITLE
Fix: Correct obs_decoder call in world model loss

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -854,7 +854,7 @@ class ChimeraAgent:
 
             h_t, z_t, kl_loss = world_model.rssm(obs_t, action_t, h_t, z_t)
 
-            recon_obs = world_model.obs_decoder(h_t)
+            recon_obs = world_model.obs_decoder(h_t, z_t)
             recon_loss = F.mse_loss(recon_obs, obs_t)
 
             total_kl_loss += kl_loss


### PR DESCRIPTION
The `_calculate_world_model_loss` method in `chimera_agent.py` was calling the `obs_decoder` with a missing `z_t` argument. This was introduced during the refactoring to a standard RSSM and caused a `TypeError` during training.

This commit corrects the function call to `world_model.obs_decoder(h_t, z_t)`, passing both the hidden and latent states as required. This resolves the `TypeError` and allows the training to proceed correctly.