### PR TITLE
Fix: Correct variable usage in imagination loop

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -936,8 +936,8 @@ class ChimeraAgent:
             logger.debug(f"Imagination Step {t+1}/{horizon}: action={action.float().mean().item():.2f}")
 
             with torch.no_grad():
-                h_t, _, prior_std = transition_model(z_t, action, h_t)
-                z_t = Normal(h_t, prior_std).rsample()
+                h_t, prior_mean, prior_std = transition_model(z_t, action, h_t)
+                z_t = Normal(prior_mean, prior_std).rsample()
 
             imagined_h.append(h_t)
             imagined_z.append(z_t)


### PR DESCRIPTION
A `RuntimeError` was occurring during policy training due to a tensor size mismatch. This was caused by incorrectly using the deterministic hidden state `h_t` (size 512) as the mean for a Normal distribution over the stochastic latent state `z_t` (size 128).

This commit fixes the issue by using the correct `prior_mean` variable returned from the transition model when sampling `z_t` in the imagination loop. This ensures that the tensors have matching shapes and resolves the error.