### PR TITLE
Fix: Resolve UnboundLocalError and KeyError after refactoring

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -404,6 +404,7 @@ class ChimeraAgent:
         h_normalized = None
         activation_path = []
         novelty = 0
+        winner_id = None
         # Only engage STAG if we are past the pre-training phase.
         if self.steps_done > self.world_model_pretrain_steps:
             # Use the hidden state for the STAG

--- a/backend/api/services/snn_predictor.py
+++ b/backend/api/services/snn_predictor.py
@@ -75,8 +75,12 @@ class NodePredictor(nn.Module):
     @classmethod
     def from_state(cls, state_dict, device='cpu'):
         """Creates a NodePredictor instance from a state dictionary."""
+        embedding_dim = state_dict.get('embedding_dim', state_dict.get('input_dim'))
+        if embedding_dim is None:
+            raise KeyError("State is missing 'embedding_dim' or 'input_dim'.")
+
         predictor = cls(
-            embedding_dim=state_dict['embedding_dim'],
+            embedding_dim=embedding_dim,
             hidden_dim=state_dict['hidden_dim'],
             max_nodes=state_dict['max_nodes'],
             num_layers=state_dict.get('num_layers', 1)


### PR DESCRIPTION
This commit fixes two critical bugs that were introduced during the recent architectural refactorings:

1.  **Fix `UnboundLocalError` in `perceive_and_update_state`**: The `winner_id` variable was not initialized in all code paths, leading to an `UnboundLocalError` if the STAG framework was not engaged (e.g., during the pre-training phase). This is fixed by initializing `winner_id = None` at the beginning of the method.

2.  **Fix `KeyError` on state loading**: The new `NodePredictor` expected an `embedding_dim` key in its saved state, but older states saved by the `SNNPredictor` used an `input_dim` key. This caused a `KeyError` when an actor with the new code tried to load a state saved by a learner with the old code. The `NodePredictor.from_state` method has been made backward-compatible to handle both keys.

These fixes resolve the crashes reported by the user and improve the agent's stability and robustness to state versioning issues.