### PR TITLE
Fix: Prevent epsilon reset in actor

### DIFF
--- a/backend/api/management/commands/launch_agent.py
+++ b/backend/api/management/commands/launch_agent.py
@@ -134,7 +134,7 @@ class Command(BaseCommand):
                             serialized_state = redis_client.get('chimera_agent_state:latest')
                             if serialized_state:
                                 state_dict = pickle.loads(serialized_state)
-                                actor_agent.load_state_dict(state_dict)
+                                actor_agent.load_actor_state_dict(state_dict)
                                 last_known_version = current_version
                     except Exception as e:
                         logger.error(f"Error loading agent state from Redis: {e}")


### PR DESCRIPTION
The actor process was incorrectly calling `load_state_dict` when updating its model from the learner. This caused the actor's internal step count to be overwritten with the learner's, which was always zero. As a result, the epsilon for exploration was constantly being reset, preventing the agent from transitioning to the exploitation phase.

This commit fixes the issue by changing the function call to `load_actor_state_dict`. This specialized function only loads the necessary model weights and leaves the actor's internal state, including the step count, intact. This ensures the epsilon decay schedule proceeds correctly throughout the training process.