### PR TITLE
Fix: Include winner_id in learner's experience push

### DIFF
--- a/backend/api/management/commands/train_agent.py
+++ b/backend/api/management/commands/train_agent.py
@@ -119,7 +119,7 @@ class Command(BaseCommand):
                         exp = Experience(*exp_tuple)
                         learner_agent.replay_buffer.push(
                             exp.h_t, exp.z_t, exp.activation_path, exp.obs, exp.action,
-                            exp.log_prob, exp.reward, exp.next_obs, exp.done, exp.goal
+                            exp.log_prob, exp.reward, exp.next_obs, exp.done, exp.goal, exp.winner_id
                         )
 
                     train_stats = learner_agent.train(cortex_id=cortex_id)


### PR DESCRIPTION
The learner process was not including the `winner_id` when pushing experiences into its internal replay buffer. This was causing a `TypeError` because the `Experience` named tuple now requires this field after the recent SNN refactoring.

This commit corrects the `replay_buffer.push` call in `train_agent.py` to include the `exp.winner_id`, ensuring that the learner's replay buffer is populated correctly and resolving the crash.