### PR TITLE
Refactor SNN predictor to prevent training errors.

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -596,11 +596,8 @@ class ChimeraAgent:
 
                     if len(history_embeddings) == self.snn_history_length:
                         history_tensor = torch.from_numpy(history_embeddings).float().to(self.device).unsqueeze(0)
-                        predicted_node_logits = stag.snn_predictor(history_tensor)
-                        predicted_node_id = torch.argmax(predicted_node_logits, dim=-1).item()
-
-                        if predicted_node_id in terminal_gng.nodes:
-                            snn_prediction_vector = torch.from_numpy(terminal_gng.nodes[predicted_node_id]['weight']).float().to(self.device).unsqueeze(0)
+                        # The new predictor returns an embedding directly.
+                        snn_prediction_vector = stag.snn_predictor(history_tensor)
 
                 # Use the hidden state for the policy
                 h_normalized = self.h_norm(self.hidden_state)
@@ -726,12 +723,13 @@ class ChimeraAgent:
         stats['std'] = max(stats['std'], 1e-6)
 
 
-    def record_experience(self, h_t, z_t, activation_path, obs, action, log_prob, reward, next_obs, done):
+    def record_experience(self, h_t, z_t, activation_path, obs, action, log_prob, reward, next_obs, done, winner_id=None):
         """Pushes an experience to the replay buffer and updates subgoal counters."""
         h_t_np = h_t.detach().cpu().numpy()
         z_t_np = z_t.detach().cpu().numpy()
 
-        experience = (h_t_np, z_t_np, activation_path, obs, action, log_prob.item(), reward, next_obs, done, self.current_goal)
+        log_prob_val = log_prob.item() if hasattr(log_prob, 'item') else log_prob
+        experience = (h_t_np, z_t_np, activation_path, obs, action, log_prob_val, reward, next_obs, done, self.current_goal, winner_id)
         self.replay_buffer.push(*experience)
 
         self.subgoal_reward += reward
@@ -780,31 +778,53 @@ class ChimeraAgent:
     def _train_snn_on_batch(self, batch):
         """
         Trains the NodePredictor on a batch of sequences of STAG node activations.
+        This version is robust to pruned nodes from the GNG and uses embedding prediction.
         """
         if not self.active_skill_id:
             return {}
 
         stag = self.skill_manager._get_or_create_stag(self.active_skill_id)
+        if not stag.level_map:
+            return {}
         terminal_gng = stag.level_map[max(stag.level_map.keys())]
+        if not terminal_gng.nodes:
+            return {}
 
-        # The replay buffer now returns sequences of winner_ids
-        # Shape: (batch_size, sequence_length)
+        if 'winner_id' not in batch or batch['winner_id'] is None or batch['winner_id'].size == 0:
+            return {}
         winner_id_sequence = batch['winner_id']
 
-        # The input is all but the last winner_id in each sequence
         input_node_ids = winner_id_sequence[:, :-1]
-        # The target is the last winner_id in each sequence
         target_node_ids = winner_id_sequence[:, -1]
 
-        # Convert node IDs to embeddings
-        # This can be slow if we iterate in python. A batch embedding lookup would be better.
-        # For now, this is a functional implementation.
-        input_embeddings = np.array(
-            [[terminal_gng.nodes[nid]['weight'] for nid in seq] for seq in input_node_ids]
-        )
+        sample_weight = next(iter(terminal_gng.nodes.values()))['weight']
+        zero_weight = np.zeros_like(sample_weight)
+
+        input_embeddings_list = []
+        target_embeddings_list = []
+
+        for i, seq in enumerate(input_node_ids):
+            target_nid = target_node_ids[i]
+            if target_nid in terminal_gng.nodes:
+                # Get the embedding for the target node
+                target_embedding = terminal_gng.nodes[target_nid]['weight']
+                target_embeddings_list.append(target_embedding)
+
+                # Get embeddings for the input sequence, handling pruned nodes
+                input_embedding_seq = [
+                    terminal_gng.nodes.get(nid, {'weight': zero_weight})['weight']
+                    for nid in seq
+                ]
+                input_embeddings_list.append(input_embedding_seq)
+
+        if not input_embeddings_list:
+            return {"snn_predictor_loss": 0.0}
+
+        input_embeddings = np.array(input_embeddings_list)
+        target_embeddings = np.array(target_embeddings_list)
 
         input_tensor = torch.from_numpy(input_embeddings).float().to(self.device)
-        target_tensor = torch.from_numpy(target_node_ids).long().to(self.device)
+        target_tensor = torch.from_numpy(target_embeddings).float().to(self.device)
 
         stag.snn_predictor.train()
         loss = stag.snn_predictor.train_on_batch(input_tensor, target_tensor)

--- a/backend/api/services/snn_predictor.py
+++ b/backend/api/services/snn_predictor.py
@@ -5,15 +5,14 @@ from snntorch import leaky
 
 class NodePredictor(nn.Module):
     """
-    A GRU-based network for predicting the next STAG node in a sequence.
+    A GRU-based network for predicting the next STAG node's embedding in a sequence.
     This network takes a sequence of historical node embeddings and outputs a
-    probability distribution over the next possible nodes.
+    predicted embedding for the next node.
     """
-    def __init__(self, embedding_dim, hidden_dim, max_nodes, num_layers=1):
+    def __init__(self, embedding_dim, hidden_dim, num_layers=1, **kwargs):
         super().__init__()
         self.embedding_dim = embedding_dim
         self.hidden_dim = hidden_dim
-        self.max_nodes = max_nodes
         self.num_layers = num_layers
 
         self.gru = nn.GRU(
@@ -22,10 +21,10 @@ class NodePredictor(nn.Module):
             num_layers=self.num_layers,
             batch_first=True
         )
-        self.fc = nn.Linear(self.hidden_dim, self.max_nodes)
+        self.fc = nn.Linear(self.hidden_dim, self.embedding_dim)
 
         self.optimizer = torch.optim.Adam(self.parameters(), lr=1e-3)
-        self.loss_fn = nn.CrossEntropyLoss()
+        self.loss_fn = nn.MSELoss()
 
     def forward(self, input_sequence, h_0=None):
         """
@@ -36,27 +35,27 @@ class NodePredictor(nn.Module):
             h_0 (torch.Tensor, optional): Initial hidden state. Defaults to None.
 
         Returns:
-            torch.Tensor: Logits for the next node prediction, shape (batch_size, max_nodes).
+            torch.Tensor: The predicted embedding for the next node, shape (batch_size, embedding_dim).
         """
         gru_out, _ = self.gru(input_sequence, h_0)
         # We only need the output of the last time step
         last_hidden_state = gru_out[:, -1, :]
-        logits = self.fc(last_hidden_state)
-        return logits
+        predicted_embedding = self.fc(last_hidden_state)
+        return predicted_embedding
 
-    def train_on_batch(self, input_sequence, target_node_indices):
+    def train_on_batch(self, input_sequence, target_embeddings):
         """
         Trains the NodePredictor on a batch of sequences.
 
         Args:
             input_sequence (torch.Tensor): Input sequences of node embeddings.
                                            Shape: (batch_size, sequence_length, embedding_dim)
-            target_node_indices (torch.Tensor): Target next node indices.
-                                                 Shape: (batch_size,)
+            target_embeddings (torch.Tensor): Target next node embeddings.
+                                              Shape: (batch_size, embedding_dim)
         """
         self.optimizer.zero_grad()
-        logits = self.forward(input_sequence)
-        loss = self.loss_fn(logits, target_node_indices)
+        predicted_embeddings = self.forward(input_sequence)
+        loss = self.loss_fn(predicted_embeddings, target_embeddings)
         loss.backward()
         self.optimizer.step()
         return loss.item()
@@ -68,21 +67,19 @@ class NodePredictor(nn.Module):
             'optimizer_state_dict': self.optimizer.state_dict(),
             'embedding_dim': self.embedding_dim,
             'hidden_dim': self.hidden_dim,
-            'max_nodes': self.max_nodes,
             'num_layers': self.num_layers
         }
 
     @classmethod
     def from_state(cls, state_dict, device='cpu'):
         """Creates a NodePredictor instance from a state dictionary."""
-        embedding_dim = state_dict.get('embedding_dim', state_dict.get('input_dim'))
+        embedding_dim = state_dict.get('embedding_dim')
         if embedding_dim is None:
-            raise KeyError("State is missing 'embedding_dim' or 'input_dim'.")
+            raise KeyError("State is missing 'embedding_dim'.")
 
         predictor = cls(
             embedding_dim=embedding_dim,
             hidden_dim=state_dict['hidden_dim'],
-            max_nodes=state_dict['max_nodes'],
             num_layers=state_dict.get('num_layers', 1)
         )
         predictor.load_state_dict(state_dict['state_dict'])

--- a/backend/api/services/stag_framework.py
+++ b/backend/api/services/stag_framework.py
@@ -31,11 +31,9 @@ class STAG_Framework:
 
         # --- Node Predictor Component ---
         snn_hidden_dim = kwargs.get('snn_hidden_dim', 128)
-        max_nodes = kwargs.get('gng_max_nodes', 1000) # Default to 1000 if not specified
         self.snn_predictor = NodePredictor(
             embedding_dim=self.dimensions,
-            hidden_dim=snn_hidden_dim,
-            max_nodes=max_nodes
+            hidden_dim=snn_hidden_dim
         )
 
     def _create_tree_node(self, parent_gng_node_id=None):

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -282,24 +282,31 @@ class PredictiveCodingTests(TestCase):
         self.embedding_dim = 64
         self.latent_dim = 32
         self.hidden_dim = 128
+        self.action_dim = 4
         self.batch_size = 4
 
         # Mock models
         self.encoder = torch.nn.Linear(self.embedding_dim, self.latent_dim)
         self.decoder = torch.nn.Linear(self.latent_dim, self.embedding_dim)
-        self.transition = torch.nn.Linear(self.hidden_dim, self.latent_dim)
+
 
     def test_predictive_coding_module_forward_pass(self):
         """Tests the forward pass of a single PredictiveCodingModule."""
         from .services.predictive_coding import PredictiveCodingModule
-        pc_module = PredictiveCodingModule(self.encoder, self.decoder, self.transition)
+        pc_module = PredictiveCodingModule(
+            self.encoder, self.decoder, self.latent_dim, self.hidden_dim, self.action_dim
+        )
 
         # Dummy data
         x = torch.rand(self.batch_size, self.embedding_dim)
-        state = torch.rand(self.batch_size, self.hidden_dim)
+        action = torch.randint(0, self.action_dim, (self.batch_size,))
+        h_prev = torch.rand(self.batch_size, self.hidden_dim)
+        z_prev = torch.rand(self.batch_size, self.latent_dim)
 
-        prediction, error, reconstruction = pc_module(x, state)
+        h_next, z_next, prediction, error, reconstruction = pc_module(x, action, h_prev, z_prev)
 
+        self.assertEqual(h_next.shape, (self.batch_size, self.hidden_dim))
+        self.assertEqual(z_next.shape, (self.batch_size, self.latent_dim))
         self.assertEqual(prediction.shape, (self.batch_size, self.latent_dim))
         self.assertEqual(error.shape, (self.batch_size, self.latent_dim))
         self.assertEqual(reconstruction.shape, (self.batch_size, self.embedding_dim))
@@ -311,42 +318,50 @@ class PredictiveCodingTests(TestCase):
         # Level 0
         l0_encoder = torch.nn.Linear(self.embedding_dim, self.latent_dim)
         l0_decoder = torch.nn.Linear(self.latent_dim, self.embedding_dim)
-        l0_transition = torch.nn.Linear(self.hidden_dim, self.latent_dim)
-        level0 = PredictiveCodingModule(l0_encoder, l0_decoder, l0_transition)
+        level0 = PredictiveCodingModule(l0_encoder, l0_decoder, self.latent_dim, self.hidden_dim, self.action_dim)
 
         # Level 1 (takes error from level 0 as input)
         l1_encoder = torch.nn.Linear(self.latent_dim, self.latent_dim)
         l1_decoder = torch.nn.Linear(self.latent_dim, self.latent_dim)
-        l1_transition = torch.nn.Linear(self.hidden_dim, self.latent_dim)
-        level1 = PredictiveCodingModule(l1_encoder, l1_decoder, l1_transition)
+        level1 = PredictiveCodingModule(l1_encoder, l1_decoder, self.latent_dim, self.hidden_dim, self.action_dim)
 
         h_rssm = HierarchicalRSSM([level0, level1])
 
         # Dummy data
         x = torch.rand(self.batch_size, self.embedding_dim)
-        states = [
+        action = torch.randint(0, self.action_dim, (self.batch_size,))
+        prev_h = [
             torch.rand(self.batch_size, self.hidden_dim), # State for level 0
             torch.rand(self.batch_size, self.hidden_dim)  # State for level 1
         ]
+        prev_z = [
+            torch.rand(self.batch_size, self.latent_dim), # State for level 0
+            torch.rand(self.batch_size, self.latent_dim)  # State for level 1
+        ]
 
-        next_states, errors, reconstructions = h_rssm(x, states)
 
-        self.assertIsInstance(next_states, list)
-        self.assertIsInstance(errors, list)
-        self.assertIsInstance(reconstructions, list)
-        self.assertEqual(len(next_states), 2)
-        self.assertEqual(len(errors), 2)
-        self.assertEqual(len(reconstructions), 2)
+        all_h_next, all_z_next, all_reconstructions, all_errors, kl_loss = h_rssm(x, action, prev_h, prev_z)
+
+        self.assertIsInstance(all_h_next, list)
+        self.assertIsInstance(all_z_next, list)
+        self.assertIsInstance(all_errors, list)
+        self.assertIsInstance(all_reconstructions, list)
+        self.assertEqual(len(all_h_next), 2)
+        self.assertEqual(len(all_z_next), 2)
+        self.assertEqual(len(all_errors), 2)
+        self.assertEqual(len(all_reconstructions), 2)
 
         # Check shapes of level 0 outputs
-        self.assertEqual(next_states[0].shape, (self.batch_size, self.latent_dim))
-        self.assertEqual(errors[0].shape, (self.batch_size, self.latent_dim))
-        self.assertEqual(reconstructions[0].shape, (self.batch_size, self.embedding_dim))
+        self.assertEqual(all_h_next[0].shape, (self.batch_size, self.hidden_dim))
+        self.assertEqual(all_z_next[0].shape, (self.batch_size, self.latent_dim))
+        self.assertEqual(all_errors[0].shape, (self.batch_size, self.latent_dim))
+        self.assertEqual(all_reconstructions[0].shape, (self.batch_size, self.embedding_dim))
 
         # Check shapes of level 1 outputs
-        self.assertEqual(next_states[1].shape, (self.batch_size, self.latent_dim))
-        self.assertEqual(errors[1].shape, (self.batch_size, self.latent_dim))
-        self.assertEqual(reconstructions[1].shape, (self.batch_size, self.latent_dim))
+        self.assertEqual(all_h_next[1].shape, (self.batch_size, self.hidden_dim))
+        self.assertEqual(all_z_next[1].shape, (self.batch_size, self.latent_dim))
+        self.assertEqual(all_errors[1].shape, (self.batch_size, self.latent_dim))
+        self.assertEqual(all_reconstructions[1].shape, (self.batch_size, self.latent_dim))
 
 
 class StateHistoryManagerTests(TestCase):

--- a/backend/api/tests_stag.py
+++ b/backend/api/tests_stag.py
@@ -57,7 +57,7 @@ class ChimeraAgentStagDecouplingTests(TestCase):
 
         # 1. Test perceive_and_update_state
         # STAG should not be engaged, so activation_path should be empty.
-        _, _, _, activation_path, novelty = self.agent.perceive_and_update_state("test_cortex", state)
+        _, _, _, activation_path, novelty, _ = self.agent.perceive_and_update_state("test_cortex", state)
         self.assertEqual(activation_path, [])
         self.assertEqual(novelty, 0)
 
@@ -120,7 +120,8 @@ class ChimeraAgentStagDecouplingTests(TestCase):
                         return torch.randn(batch_dim, self.agent.max_action_dim, device=input_tensor.device)
                     mock_action_layer_forward.side_effect = mock_forward_dynamic
 
-                    self.agent.train_policy_in_imagination()
+                    batch, _, _ = mock_buffer.sample.return_value
+                    self.agent.train_policy_in_imagination(batch)
 
                     # Get the input to the action head from the LAST call, which is the one for the BC loss.
                     call_args, _ = mock_action_layer_forward.call_args
@@ -145,7 +146,7 @@ class ChimeraAgentStagDecouplingTests(TestCase):
 
         # 1. Test perceive_and_update_state
         # STAG should now be engaged, so activation_path should not be empty.
-        _, _, h_normalized, activation_path, _ = self.agent.perceive_and_update_state("test_cortex", state)
+        _, _, h_normalized, activation_path, _, _ = self.agent.perceive_and_update_state("test_cortex", state)
         self.assertNotEqual(activation_path, [])
 
         # 2. Test update_stag frequency


### PR DESCRIPTION
The SNN predictor was refactored to predict node embeddings directly instead of node IDs. This decouples the predictor from the dynamic GNG node structure and prevents `KeyError` exceptions that occurred when the replay buffer contained IDs of nodes that had been pruned from the GNG.

The `NodePredictor` class was updated to output an embedding vector, and its loss function was changed to `MSELoss`. The training method `_train_snn_on_batch` in `ChimeraAgent` was updated to provide target embeddings. The `select_action` method was also updated to use the predicted embedding directly.

Associated tests were updated to reflect these changes.