### PR TITLE
Refactor SNN predictor and STAG context handling.

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -594,6 +594,7 @@ class ChimeraAgent:
                         [terminal_gng.nodes[nid]['weight'] for nid in history_node_ids if nid in terminal_gng.nodes]
                     )
 
+                    logger.info(f"[SNN-Debug] History length: {len(history_embeddings)}, Required: {self.snn_history_length}")
                     if len(history_embeddings) == self.snn_history_length:
                         history_tensor = torch.from_numpy(history_embeddings).float().to(self.device).unsqueeze(0)
                         # The new predictor returns an embedding directly.
@@ -650,11 +651,11 @@ class ChimeraAgent:
 
         path_tensors = []
         for step in activation_path:
-            level = step.get('level')
-            node_id = step.get('node_id')
-            if level is not None and node_id is not None and \
-               level in stag.level_map and node_id in stag.level_map[level]['gng'].nodes:
-                weight = stag.level_map[level]['gng'].nodes[node_id]['weight']
+            level_id = step.get('level_id')
+            winner_id = step.get('winner_id')
+            if level_id is not None and winner_id is not None and \
+               level_id in stag.level_map and winner_id in stag.level_map[level_id].nodes:
+                weight = stag.level_map[level_id].nodes[winner_id]['weight']
                 path_tensors.append(torch.from_numpy(weight).float().to(self.device))
 
         if not path_tensors:

--- a/backend/api/tests.py
+++ b/backend/api/tests.py
@@ -213,7 +213,8 @@ class ChimeraAgentTests(TestCase):
                 0.5,                                  # log_prob
                 1.0,                                  # reward
                 np.random.rand(self.obs_dim),         # next_obs
-                False                                 # done
+                False,                                # done
+                winner_id=None
             )
 
         self.assertEqual(len(self.agent.replay_buffer), sequence_length + 5)
@@ -236,7 +237,8 @@ class ChimeraAgentTests(TestCase):
                 0.5,                                  # log_prob
                 1.0,                                  # reward
                 np.random.rand(self.obs_dim),         # next_obs
-                False                                 # done
+                False,                                # done
+                winner_id=None
             )
             # Train on a new batch
             train_stats = self.agent.train(cortex_id="test_cortex")

--- a/backend/api/tests_run_colosseum_agents.py
+++ b/backend/api/tests_run_colosseum_agents.py
@@ -42,7 +42,8 @@ class RunColosseumAgentsTests(unittest.TestCase):
             torch.zeros(1, 128),
             np.zeros(512),
             [],
-            0.0
+            0.0,
+            None  # winner_id
         )
         mock_agent_instance.select_action.return_value = (
             0,

--- a/backend/run_colosseum_agents.py
+++ b/backend/run_colosseum_agents.py
@@ -140,7 +140,7 @@ async def run_training_curriculum():
 
                 while not done:
                     # Perceive, act, and learn
-                    h_t, z_t, h_normalized, activation_path, novelty = agent.perceive_and_update_state(cortex_id, current_obs)
+                    h_t, z_t, h_normalized, activation_path, novelty, winner_id = agent.perceive_and_update_state(cortex_id, current_obs)
                     action, log_prob, _, _, _ = agent.select_action(actual_action_dim, activation_path)
 
                     await connector.send_action(action)
@@ -156,7 +156,7 @@ async def run_training_curriculum():
                         reward = msg.get("reward")
                         done = msg.get("done")
 
-                        agent.record_experience(h_t, z_t, activation_path, current_obs, action, log_prob, reward, next_obs, done)
+                        agent.record_experience(h_t, z_t, activation_path, current_obs, action, log_prob, reward, next_obs, done, winner_id)
                         current_obs = next_obs
                         episode_reward += reward
 

--- a/backend/train.py
+++ b/backend/train.py
@@ -120,13 +120,13 @@ def main(args):
                 terminated, truncated = False, False
 
                 while not (terminated or truncated):
-                    h_t, z_t, h_normalized, activation_path, novelty = agent.perceive_and_update_state(cortex_id, state)
+                    h_t, z_t, h_normalized, activation_path, novelty, winner_id = agent.perceive_and_update_state(cortex_id, state)
                     action, log_prob, _, _, _, _ = agent.select_action(actual_action_dim, activation_path)
                     next_state, env_reward, terminated, truncated, _ = env.step(action)
                     agent.update_stag(h_normalized, env_reward)
                     internal_reward = agent.get_internal_reward(damage_taken=0, novelty_signal=novelty)
                     total_reward = env_reward + internal_reward
-                    agent.record_experience(h_t, z_t, activation_path, state, action, log_prob, total_reward, next_state, terminated)
+                    agent.record_experience(h_t, z_t, activation_path, state, action, log_prob, total_reward, next_state, terminated, winner_id)
                     state = next_state
                     episode_reward += env_reward
                     total_steps += 1


### PR DESCRIPTION
The SNN predictor was refactored to predict node embeddings directly instead of node IDs. This decouples the predictor from the dynamic GNG node structure and prevents `KeyError` exceptions that occurred when the replay buffer contained IDs of nodes that had been pruned from the GNG.

The `NodePredictor` class was updated to output an embedding vector, and its loss function was changed to `MSELoss`. The training method `_train_snn_on_batch` in `ChimeraAgent` was updated to provide target embeddings. The `select_action` method was also updated to use the predicted embedding directly.

The `_prepare_stag_context` method was fixed to use the correct keys (`level_id`, `winner_id`) when processing the activation path, ensuring the STAG context is correctly calculated and used in the agent's decisions.