### PR TITLE
Refactor SNN predictor and fix STAG context

### DIFF
--- a/backend/api/services/chimera_agent.py
+++ b/backend/api/services/chimera_agent.py
@@ -829,6 +829,7 @@ class ChimeraAgent:
 
         stag.snn_predictor.train()
         loss = stag.snn_predictor.train_on_batch(input_tensor, target_tensor)
+        logger.info(f"[SNN-Training] SNN predictor loss: {loss:.4f}")
 
         return {"snn_predictor_loss": loss}
 


### PR DESCRIPTION
- Refactored the `NodePredictor` to predict node embeddings directly instead of node IDs. This decouples the predictor from the dynamic GNG node structure and prevents `KeyError` exceptions from pruned nodes.
- Changed the `NodePredictor` loss function to `MSELoss`.
- Updated `_train_snn_on_batch` to provide target embeddings and handle pruned nodes in the input sequence.
- Updated `select_action` to use the predicted embedding from the new SNN predictor.
- Fixed a bug in `_prepare_stag_context` where incorrect keys were used, causing the STAG context to be a zero vector.
- Updated all relevant function call sites and tests to be compatible with the new method signatures and logic.
- Added logging to SNN training to monitor the loss.